### PR TITLE
update JSON-Schema-Test-Suite; make ajv compatible with draft-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,24 @@ for validators that cause side-effects on schema or data.
 
 # Performance
 
-![performance](https://chart.googleapis.com/chart?chxt=x,y&cht=bhs&chco=76A4FB&chls=2.0&chbh=40,4,1&chs=600x416&chxl=-1:|djv|json-schema-validator-generator|ajv|is-my-json-valid|schemasaurus|jsck|z-schema|jsonschema|tv4&chd=t:100,91.1,83,59.6,23.1,6.6,6.4,0.8,0.4)
+![performance](https://chart.googleapis.com/chart?chxt=x,y&cht=bhs&chco=76A4FB&chls=2.0&chbh=36,4,1&chs=600x420&chxl=-1:|djv|ajv|jsen|is-my-json-valid|schemasaurus|themis|z-schema|jsck|jsonschema|tv4&chd=t:100,87.8,59.2,54.7,15,13.8,5.3,4.8,0.8,0.4)
 
 |Validator|Relative speed|Number of test runs per second|
 |---------|:------------:|:----------------------------:|
-|[`djv`](https://github.com/korzio/djv#readme)|100%|21374 (± 2.27%)|
-|json-schema-validator-generator|91.1%|19475 (± 1.88%)|
-|[`ajv`](https://github.com/epoberezkin/ajv)|83%|17744 (± 4.04%)|
-|[`is-my-json-valid`](https://github.com/mafintosh/is-my-json-valid)|59.6%|12745 (± 2.81%)|
-|[`schemasaurus`](https://github.com/AlexeyGrishin/schemasaurus)|23.1%|4929 (± 3.95%)|
-|[`jsck`](https://github.com/pandastrike/jsck#readme)|6.6%|1414 (± 2.83%)|
-|[`z-schema`](https://github.com/zaggino/z-schema)|6.4%|1371 (± 2.58%)|
-|[`jsonschema`](https://github.com/tdegrunt/jsonschema#readme)|0.8%|165 (± 2.9%)|
-|[`tv4`](https://github.com/geraintluff/tv4)|0.4%|87 (± 2.03%)|
+|[`djv`](https://github.com/korzio/djv#readme)|100%|30718 (± 2.83%)|
+|[`ajv`](https://github.com/epoberezkin/ajv)|87.8%|26971 (± 3.37%)|
+|[`jsen`](https://github.com/bugventure/jsen)|59.2%|18174 (± 7.39%)|
+|[`is-my-json-valid`](https://github.com/mafintosh/is-my-json-valid)|54.7%|16809 (± 0.74%)|
+|[`schemasaurus`](https://github.com/AlexeyGrishin/schemasaurus)|15%|4594 (± 2.07%)|
+|[`themis`](https://github.com/playlyfe/themis)|13.8%|4241 (± 6.04%)|
+|[`z-schema`](https://github.com/zaggino/z-schema)|5.3%|1643 (± 0.62%)|
+|[`jsck`](https://github.com/pandastrike/jsck#readme)|4.8%|1469 (± 2.63%)|
+|[`jsonschema`](https://github.com/tdegrunt/jsonschema#readme)|0.8%|244 (± 3.46%)|
+|[`tv4`](https://github.com/geraintluff/tv4)|0.4%|113 (± 2.06%)|
 
 235 tests are run in each test run.
 
-Validators tested: json-schema-validator-generator, [`is-my-json-valid (2.16.0)`](https://github.com/mafintosh/is-my-json-valid), [`ajv (5.0.0)`](https://github.com/epoberezkin/ajv), [`z-schema (3.18.2)`](https://github.com/zaggino/z-schema), [`jjv (1.0.2)`](https://github.com/acornejo/jjv), [`djv (1.0.0-beta.0)`](https://github.com/korzio/djv#readme), [`skeemas (1.2.2)`](https://github.com/Prestaul/skeemas#readme), [`jayschema (0.3.1)`](https://github.com/natesilva/jayschema), [`schemasaurus (0.7.8)`](https://github.com/AlexeyGrishin/schemasaurus), [`jsck (0.3.0)`](https://github.com/pandastrike/jsck#readme), [`jassi (0.1.2)`](https://github.com/iclanzan/jassi), [`JSV (4.0.2)`](http://github.com/garycourt/JSV), [`request-validator (0.3.3)`](https://github.com/bugventure/request-validator), [`json-gate (0.8.23)`](https://github.com/oferei/json-gate#readme), [`json-model (0.2.24)`](https://github.com/geraintluff/json-model), [`tv4 (1.3.0)`](https://github.com/geraintluff/tv4), [`jsonschema (1.1.1)`](https://github.com/tdegrunt/jsonschema#readme), [`revalidator (0.3.1)`](https://github.com/flatiron/revalidator), 
+Validators tested: json-schema-validator-generator, [`is-my-json-valid (2.16.0)`](https://github.com/mafintosh/is-my-json-valid), [`jsen (0.6.4)`](https://github.com/bugventure/jsen), [`ajv (5.1.5)`](https://github.com/epoberezkin/ajv), [`themis (1.1.6)`](https://github.com/playlyfe/themis), [`z-schema (3.18.2)`](https://github.com/zaggino/z-schema), [`jjv (1.0.2)`](https://github.com/acornejo/jjv), [`djv (1.0.0-beta.0)`](https://github.com/korzio/djv#readme), [`skeemas (1.2.2)`](https://github.com/Prestaul/skeemas#readme), [`jayschema (0.3.1)`](https://github.com/natesilva/jayschema), [`schemasaurus (0.7.8)`](https://github.com/AlexeyGrishin/schemasaurus), [`jsck (0.3.1)`](https://github.com/pandastrike/jsck#readme), [`jassi (0.1.2)`](https://github.com/iclanzan/jassi), [`JSV (4.0.2)`](http://github.com/garycourt/JSV), [`request-validator (0.3.3)`](https://github.com/bugventure/request-validator), [`json-gate (0.8.23)`](https://github.com/oferei/json-gate#readme), [`json-model (0.2.24)`](https://github.com/geraintluff/json-model), [`tv4 (1.3.0)`](https://github.com/geraintluff/tv4), [`jsonschema (1.1.1)`](https://github.com/tdegrunt/jsonschema#readme), [`revalidator (0.3.1)`](https://github.com/flatiron/revalidator), 
 
 (validators not in the results above where excluded because of failing tests - see below for details)
 
@@ -40,28 +41,30 @@ This test suite uses the [official JSON-schema test suite](https://github.com/js
 
 If a validator does not pass a test in the official test suite, it will show up in these results.
 
-![failing tests](https://chart.googleapis.com/chart?chxt=x,y&cht=bhs&chco=76A4FB&chls=2.0&chbh=18,4,1&chs=600x416&chxl=-1:|z-schema|jsonschema|skeemas|is-my-json-valid|jjv|ajv|jayschema|djv|schemasaurus|jsck|tv4|json-schema-validator-generator|request-validator|jassi|json-model|JSV|json-gate|revalidator&chd=t:8,10,14,14,17,17,19,20,27,29,30,31,36,39,51,67,80,148&chxr=0,0,148&chds=0,148)
+![failing tests](https://chart.googleapis.com/chart?chxt=x,y&cht=bhs&chco=76A4FB&chls=2.0&chbh=16,4,1&chs=600x420&chxl=-1:|ajv|jsen|z-schema|jsonschema|is-my-json-valid|skeemas|jjv|djv|jayschema|themis|schemasaurus|jsck|tv4|request-validator|jassi|json-model|JSV|json-gate|revalidator|json-schema-validator-generator&chd=t:1,5,8,10,14,14,17,18,19,24,27,29,30,36,39,51,67,80,148,159&chxr=0,0,159&chds=0,159)
 
 |Validator|Number of failing tests (click for details)|
 |---------|-----------------------|
+|[`ajv`](https://github.com/epoberezkin/ajv)|[1](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/ajv.md)|
+|[`jsen`](https://github.com/bugventure/jsen)|[5](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/jsen.md)|
 |[`z-schema`](https://github.com/zaggino/z-schema)|[8](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/z-schema.md)|
 |[`jsonschema`](https://github.com/tdegrunt/jsonschema#readme)|[10](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/jsonschema.md)|
-|[`skeemas`](https://github.com/Prestaul/skeemas#readme)|[14](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/skeemas.md)|
 |[`is-my-json-valid`](https://github.com/mafintosh/is-my-json-valid)|[14](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/is-my-json-valid.md)|
+|[`skeemas`](https://github.com/Prestaul/skeemas#readme)|[14](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/skeemas.md)|
 |[`jjv`](https://github.com/acornejo/jjv)|[17](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/jjv.md)|
-|[`ajv`](https://github.com/epoberezkin/ajv)|[17](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/ajv.md)|
+|[`djv`](https://github.com/korzio/djv#readme)|[18](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/djv.md)|
 |[`jayschema`](https://github.com/natesilva/jayschema)|[19](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/jayschema.md)|
-|[`djv`](https://github.com/korzio/djv#readme)|[20](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/djv.md)|
+|[`themis`](https://github.com/playlyfe/themis)|[24](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/themis.md)|
 |[`schemasaurus`](https://github.com/AlexeyGrishin/schemasaurus)|[27](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/schemasaurus.md)|
 |[`jsck`](https://github.com/pandastrike/jsck#readme)|[29](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/jsck.md)|
 |[`tv4`](https://github.com/geraintluff/tv4)|[30](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/tv4.md)|
-|json-schema-validator-generator|[31](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/json-schema-validator-generator.md)|
 |[`request-validator`](https://github.com/bugventure/request-validator)|[36](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/request-validator.md)|
 |[`jassi`](https://github.com/iclanzan/jassi)|[39](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/jassi.md)|
 |[`json-model`](https://github.com/geraintluff/json-model)|[51](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/json-model.md)|
 |[`JSV`](http://github.com/garycourt/JSV)|[67](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/JSV.md)|
 |[`json-gate`](https://github.com/oferei/json-gate#readme)|[80](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/json-gate.md)|
 |[`revalidator`](https://github.com/flatiron/revalidator)|[148](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/revalidator.md)|
+|json-schema-validator-generator|[159](https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/json-schema-validator-generator.md)|
 
 Some validators have deliberately chosen not to support parts of the spec. Go to the homepage of the validator to learn if
 that is the case for these tests.
@@ -87,6 +90,8 @@ you to take a look at each validator if you are looking for special features.
 
 Several of the validators have build benchmarks themselves. They are
 more detailed then the benchmarks provided above.
+
+[Benchmarks owned by themis](https://cdn.rawgit.com/playlyfe/themis/master/benchmark/results.html)
 
 [Benchmarks owned by z-schema](https://rawgit.com/zaggino/z-schema/master/benchmark/results.html)
 

--- a/index.js
+++ b/index.js
@@ -22,19 +22,17 @@ var djv = require('djv')();
 var jsvg = require('json-schema-validator-generator').default;
 
 var refs = {
+	'http://json-schema.org/draft-04/schema': require('./refs/json-schema-draft-04.json'),
 	'http://localhost:1234/integer.json': require('./JSON-Schema-Test-Suite/remotes/integer.json'),
 	'http://localhost:1234/subSchemas.json': require('./JSON-Schema-Test-Suite/remotes/subSchemas.json'),
 	'http://localhost:1234/name.json': require('./JSON-Schema-Test-Suite/remotes/name.json'),
-	'http://localhost:1234/folder/folderInteger.json': require('./JSON-Schema-Test-Suite/remotes/folder/folderInteger.json'),
-	'http://json-schema.org/draft-03/schema': require('./refs/json-schema-draft-03.json'),
-	'http://json-schema.org/draft-04/schema': require('./refs/json-schema-draft-04.json')
+	'http://localhost:1234/folder/folderInteger.json': require('./JSON-Schema-Test-Suite/remotes/folder/folderInteger.json')
 };
 
-Object.keys(refs).slice(0,3).forEach(function (uri) {
+Object.keys(refs).forEach(function (uri) {
     ajv.addSchema(refs[uri], uri);
     djv.addSchema(uri, refs[uri]);
 });
-djv.addSchema('http://json-schema.org/draft-04/schema', refs['http://json-schema.org/draft-04/schema']);
 
 testRunner([
 	{
@@ -56,8 +54,7 @@ testRunner([
 			return instance(json);
 		}
 	},
-	//json throws error because of remote schema, couldn't find a way to make it not throw, so had to exclude it
-	/*{
+	{
 		name: 'jsen',
 		setup: function (schema) {
 			return jsen(schema, { schemas: refs });
@@ -65,18 +62,18 @@ testRunner([
 		test: function (instance, json, schema) {
 			return instance(json);
 		}
-	},*/
+	},
 	{
         name: 'ajv',
         setup: function(schema) {
+            ajv._opts.defaultMeta = 'http://json-schema.org/draft-04/schema';
             return ajv.compile(schema);
         },
         test: function (instance, json, schema) {
             return instance(json);
         }
     },
-	//this throws too had to exclude it: Error: invalid ref: folderInteger.json in folder/
-	/*{
+	{
 		name: 'themis',
 		setup: function (schema) {
 			// $refs only supported if they have id attributes and the test suite refs do not
@@ -86,7 +83,7 @@ testRunner([
 			return instance(json, '0').valid;
 		},
 		benchmarks: 'https://cdn.rawgit.com/playlyfe/themis/master/benchmark/results.html'
-	},*/
+	},
 	{
 		name: 'z-schema',
 		setup: function () {

--- a/reports/JSV.md
+++ b/reports/JSV.md
@@ -1,8 +1,5 @@
 # [`JSV`](http://github.com/garycourt/JSV) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`JSV`](http://github.com/garycourt/JSV) failed tests
 
@@ -55,11 +52,12 @@ that is the case for these tests.
 |`validation of host names, a host name starting with an illegal character`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name containing illegal characters`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name with a component too long`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`escaped pointer ref, slash valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
 |`escaped pointer ref, tilda valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
 |`escaped pointer ref, percent valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
 |`nested refs, nested ref valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
-|`ref overrides any sibling keywords, ref valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`ref overrides any sibling keywords, ref valid`|Expected result: `true` but validator returned: `false`
 |`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
 |`remote ref, containing refs itself, remote ref valid`|Expected result: `true` but validator returned: `false`
 |`Recursive references between schemas, valid tree`|Expected result: `true` but validator returned: `false`

--- a/reports/TESTS.template
+++ b/reports/TESTS.template
@@ -1,10 +1,12 @@
 # {{&link}} - test summary
 
+{{#testsThatAllValidatorsFail.length}}
 # All validators fail this test
 {{#testsThatAllValidatorsFail}}
 
 `{{name}}`
 {{/testsThatAllValidatorsFail}}
+{{/testsThatAllValidatorsFail.length}}
 
 {{#hasFailingTests}}
 # {{&link}} failed tests

--- a/reports/ajv.md
+++ b/reports/ajv.md
@@ -1,8 +1,5 @@
 # [`ajv`](https://github.com/epoberezkin/ajv) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`ajv`](https://github.com/epoberezkin/ajv) failed tests
 
@@ -11,22 +8,7 @@ that is the case for these tests.
 
 |test failed|reason
 |-----------|------
-|`valid definition, valid definition schema`|The schema failed to load(`can't resolve reference http://json-schema.org/draft-04/schema# from id #`)
-|`invalid definition, invalid definition schema`|The schema failed to load(`can't resolve reference http://json-schema.org/draft-04/schema# from id #`)
-|`exclusiveMaximum validation, below the maximum is still valid`|The schema failed to load(`schema is invalid: data.exclusiveMaximum should be number`)
-|`exclusiveMaximum validation, boundary point is invalid`|The schema failed to load(`schema is invalid: data.exclusiveMaximum should be number`)
-|`exclusiveMinimum validation, above the minimum is still valid`|The schema failed to load(`schema is invalid: data.exclusiveMinimum should be number`)
-|`exclusiveMinimum validation, boundary point is invalid`|The schema failed to load(`schema is invalid: data.exclusiveMinimum should be number`)
-|`float comparison with high precision, comparison works for high numbers`|The schema failed to load(`schema is invalid: data.exclusiveMaximum should be number`)
-|`float comparison with high precision on negative numbers, comparison works for very negative numbers`|The schema failed to load(`schema is invalid: data.exclusiveMinimum should be number`)
-|`remote ref, containing refs itself, remote ref valid`|The schema failed to load(`can't resolve reference http://json-schema.org/draft-04/schema# from id #`)
-|`remote ref, containing refs itself, remote ref invalid`|The schema failed to load(`can't resolve reference http://json-schema.org/draft-04/schema# from id #`)
-|`base URI change, base URI change ref valid`|The schema failed to load(`can't resolve reference folderInteger.json from id http://localhost:1234/folder/`)
-|`base URI change, base URI change ref invalid`|The schema failed to load(`can't resolve reference folderInteger.json from id http://localhost:1234/folder/`)
-|`base URI change - change folder, number is valid`|The schema failed to load(`can't resolve reference folderInteger.json from id http://localhost:1234/folder/`)
-|`base URI change - change folder, string is invalid`|The schema failed to load(`can't resolve reference folderInteger.json from id http://localhost:1234/folder/`)
-|`base URI change - change folder in subschema, number is valid`|The schema failed to load(`can't resolve reference folderInteger.json from id http://localhost:1234/folder/`)
-|`base URI change - change folder in subschema, string is invalid`|The schema failed to load(`can't resolve reference folderInteger.json from id http://localhost:1234/folder/`)
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 
 **All other tests passed**.
 

--- a/reports/djv.md
+++ b/reports/djv.md
@@ -1,8 +1,5 @@
 # [`djv`](https://github.com/korzio/djv#readme) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`djv`](https://github.com/korzio/djv#readme) failed tests
 
@@ -17,11 +14,10 @@ that is the case for these tests.
 |`an array of schemas for items, JavaScript pseudo-array is valid`|Expected result: `true` but validator returned: `false`
 |`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
 |`validation of URIs, an invalid protocol-relative URI Reference`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
 |`Recursive references between schemas, valid tree`|The schema failed to load(`Cannot read property 'schema' of undefined`)
 |`Recursive references between schemas, invalid tree`|The schema failed to load(`Cannot read property 'schema' of undefined`)
-|`base URI change, base URI change ref valid`|The schema failed to load(`Cannot read property 'schema' of undefined`)
-|`base URI change, base URI change ref invalid`|The schema failed to load(`Cannot read property 'schema' of undefined`)
 |`base URI change - change folder, number is valid`|The schema failed to load(`Cannot read property 'schema' of undefined`)
 |`base URI change - change folder, string is invalid`|The schema failed to load(`Cannot read property 'schema' of undefined`)
 |`base URI change - change folder in subschema, number is valid`|The schema failed to load(`Cannot read property 'schema' of undefined`)

--- a/reports/is-my-json-valid.md
+++ b/reports/is-my-json-valid.md
@@ -1,8 +1,5 @@
 # [`is-my-json-valid`](https://github.com/mafintosh/is-my-json-valid) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`is-my-json-valid`](https://github.com/mafintosh/is-my-json-valid) failed tests
 
@@ -16,6 +13,7 @@ that is the case for these tests.
 |`maxLength validation, two supplementary Unicode code points is long enough`|Expected result: `true` but validator returned: `false`
 |`minLength validation, one supplementary Unicode code point is not long enough`|Expected result: `false` but validator returned: `true`
 |`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
 |`remote ref, containing refs itself, remote ref invalid`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, invalid tree`|Expected result: `false` but validator returned: `true`

--- a/reports/jassi.md
+++ b/reports/jassi.md
@@ -1,8 +1,5 @@
 # [`jassi`](https://github.com/iclanzan/jassi) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`jassi`](https://github.com/iclanzan/jassi) failed tests
 
@@ -31,6 +28,7 @@ that is the case for these tests.
 |`validation of host names, a host name starting with an illegal character`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name containing illegal characters`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name with a component too long`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`root pointer ref, recursive mismatch`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`relative pointer ref to object, mismatch`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`relative pointer ref to array, mismatch array`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
@@ -39,7 +37,7 @@ that is the case for these tests.
 |`escaped pointer ref, percent invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`nested refs, nested ref invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
-|`ref overrides any sibling keywords, ref invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
+|`ref overrides any sibling keywords, ref invalid`|Expected result: `false` but validator returned: `true`
 |`remote ref, containing refs itself, remote ref invalid`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, invalid tree`|Expected result: `false` but validator returned: `true`
 |`remote ref, remote ref invalid`|Expected result: `false` but validator returned: `true`

--- a/reports/jayschema.md
+++ b/reports/jayschema.md
@@ -1,8 +1,5 @@
 # [`jayschema`](https://github.com/natesilva/jayschema) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`jayschema`](https://github.com/natesilva/jayschema) failed tests
 
@@ -16,6 +13,7 @@ that is the case for these tests.
 |`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
 |`validation of URIs, an invalid protocol-relative URI Reference`|Expected result: `false` but validator returned: `true`
 |`validation of URIs, an invalid URI though valid URI reference`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`property named $ref that is not a reference, property named $ref valid`|Expected result: `true` but validator returned: `"uri.slice is not a function"`. **This excludes this validator from performance tests**
 |`property named $ref that is not a reference, property named $ref invalid`|Expected result: `false` but validator returned: `"uri.slice is not a function"`. **This excludes this validator from performance tests**
 |`remote ref, remote ref valid`|Expected result: `true` but validator returned: `false`

--- a/reports/jjv.md
+++ b/reports/jjv.md
@@ -1,8 +1,5 @@
 # [`jjv`](https://github.com/acornejo/jjv) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`jjv`](https://github.com/acornejo/jjv) failed tests
 
@@ -17,6 +14,7 @@ that is the case for these tests.
 |`minLength validation, one supplementary Unicode code point is not long enough`|Expected result: `false` but validator returned: `true`
 |`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
 |`validation of URIs, an invalid protocol-relative URI Reference`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`escaped pointer ref, slash valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
 |`escaped pointer ref, tilda valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
 |`escaped pointer ref, percent valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**

--- a/reports/jsck.md
+++ b/reports/jsck.md
@@ -1,8 +1,5 @@
 # [`jsck`](https://github.com/pandastrike/jsck#readme) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`jsck`](https://github.com/pandastrike/jsck#readme) failed tests
 
@@ -15,6 +12,7 @@ that is the case for these tests.
 |`maxLength validation, two supplementary Unicode code points is long enough`|Expected result: `true` but validator returned: `false`
 |`minLength validation, one supplementary Unicode code point is not long enough`|Expected result: `false` but validator returned: `true`
 |`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
 |`Recursive references between schemas, valid tree`|The schema failed to load(`Unresolvable $ref values: ["http://localhost:1234/node","http://localhost:1234/tree"]`)
 |`Recursive references between schemas, invalid tree`|The schema failed to load(`Unresolvable $ref values: ["http://localhost:1234/node","http://localhost:1234/tree"]`)

--- a/reports/jsen.md
+++ b/reports/jsen.md
@@ -1,0 +1,19 @@
+# [`jsen`](https://github.com/bugventure/jsen) - test summary
+
+
+# [`jsen`](https://github.com/bugventure/jsen) failed tests
+
+Some validators have deliberately chosen not to support parts of the spec. Go to the [`jsen`](https://github.com/bugventure/jsen) homepage to learn if
+that is the case for these tests.
+
+|test failed|reason
+|-----------|------
+|`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
+|`validation of URIs, an invalid protocol-relative URI Reference`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
+|`root ref in remote ref, string is valid`|Expected result: `true` but validator returned: `false`
+|`root ref in remote ref, object is invalid`|Expected result: `false` but validator returned: `true`
+
+**All other tests passed**.
+
+[back to benchmarks](https://github.com/ebdrup/json-schema-benchmark)

--- a/reports/json-gate.md
+++ b/reports/json-gate.md
@@ -1,8 +1,5 @@
 # [`json-gate`](https://github.com/oferei/json-gate#readme) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`json-gate`](https://github.com/oferei/json-gate#readme) failed tests
 
@@ -68,6 +65,7 @@ that is the case for these tests.
 |`validation of host names, a host name starting with an illegal character`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name containing illegal characters`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name with a component too long`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`root pointer ref, recursive mismatch`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`relative pointer ref to object, mismatch`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`relative pointer ref to array, mismatch array`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
@@ -76,7 +74,7 @@ that is the case for these tests.
 |`escaped pointer ref, percent invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`nested refs, nested ref invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
-|`ref overrides any sibling keywords, ref invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
+|`ref overrides any sibling keywords, ref invalid`|Expected result: `false` but validator returned: `true`
 |`remote ref, containing refs itself, remote ref invalid`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, valid tree`|The schema failed to load(`Schema: 'required' attribute is an array when it should be a boolean`)
 |`Recursive references between schemas, invalid tree`|The schema failed to load(`Schema: 'required' attribute is an array when it should be a boolean`)

--- a/reports/json-model-side-effects.md
+++ b/reports/json-model-side-effects.md
@@ -25,7 +25,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalItems": {
 		"type": "integer"
 	},
-	"id": "9186141217748429anonymous"
+	"id": "1358526937951532anonymous"
 }
 ```
 
@@ -51,7 +51,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalItems": {
 		"type": "integer"
 	},
-	"id": "9186141217748429anonymous"
+	"id": "1358526937951532anonymous"
 }
 ```
 
@@ -69,7 +69,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"items": {},
 	"additionalItems": false,
-	"id": "5573627744506042anonymous"
+	"id": "007387988777379784anonymous"
 }
 ```
 
@@ -95,7 +95,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		{}
 	],
 	"additionalItems": false,
-	"id": "014338775892168698anonymous"
+	"id": "4729387006955985anonymous"
 }
 ```
 
@@ -121,7 +121,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		{}
 	],
 	"additionalItems": false,
-	"id": "014338775892168698anonymous"
+	"id": "4729387006955985anonymous"
 }
 ```
 
@@ -147,7 +147,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		{}
 	],
 	"additionalItems": false,
-	"id": "014338775892168698anonymous"
+	"id": "4729387006955985anonymous"
 }
 ```
 
@@ -163,7 +163,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"additionalItems": false,
-	"id": "618818972176072anonymous"
+	"id": "48733603457354957anonymous"
 }
 ```
 
@@ -179,7 +179,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"additionalItems": false,
-	"id": "618818972176072anonymous"
+	"id": "48733603457354957anonymous"
 }
 ```
 
@@ -203,7 +203,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "integer"
 		}
 	],
-	"id": "4831076728652999anonymous"
+	"id": "7710373629177794anonymous"
 }
 ```
 
@@ -233,7 +233,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"^v": {}
 	},
 	"additionalProperties": false,
-	"id": "7975622485305556anonymous"
+	"id": "0534138400596027anonymous"
 }
 ```
 
@@ -263,7 +263,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"^v": {}
 	},
 	"additionalProperties": false,
-	"id": "7975622485305556anonymous"
+	"id": "0534138400596027anonymous"
 }
 ```
 
@@ -293,7 +293,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"^v": {}
 	},
 	"additionalProperties": false,
-	"id": "7975622485305556anonymous"
+	"id": "0534138400596027anonymous"
 }
 ```
 
@@ -323,7 +323,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"^v": {}
 	},
 	"additionalProperties": false,
-	"id": "7975622485305556anonymous"
+	"id": "0534138400596027anonymous"
 }
 ```
 
@@ -351,7 +351,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "boolean"
 	},
-	"id": "23351072192558253anonymous"
+	"id": "8817104577536106anonymous"
 }
 ```
 
@@ -379,7 +379,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "boolean"
 	},
-	"id": "23351072192558253anonymous"
+	"id": "8817104577536106anonymous"
 }
 ```
 
@@ -407,7 +407,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "boolean"
 	},
-	"id": "23351072192558253anonymous"
+	"id": "8817104577536106anonymous"
 }
 ```
 
@@ -427,7 +427,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "boolean"
 	},
-	"id": "811059550896736anonymous"
+	"id": "701550528142854anonymous"
 }
 ```
 
@@ -447,7 +447,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "boolean"
 	},
-	"id": "811059550896736anonymous"
+	"id": "701550528142854anonymous"
 }
 ```
 
@@ -469,7 +469,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"foo": {},
 		"bar": {}
 	},
-	"id": "5021521415930728anonymous"
+	"id": "7527539961850647anonymous"
 }
 ```
 
@@ -527,7 +527,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "4937861212673733anonymous"
+	"id": "06602775958536133anonymous"
 }
 ```
 
@@ -585,7 +585,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "4937861212673733anonymous"
+	"id": "06602775958536133anonymous"
 }
 ```
 
@@ -643,7 +643,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "4937861212673733anonymous"
+	"id": "06602775958536133anonymous"
 }
 ```
 
@@ -701,7 +701,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "4937861212673733anonymous"
+	"id": "06602775958536133anonymous"
 }
 ```
 
@@ -775,7 +775,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "9330099904366966anonymous"
+	"id": "5098936157964886anonymous"
 }
 ```
 
@@ -849,7 +849,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "9330099904366966anonymous"
+	"id": "5098936157964886anonymous"
 }
 ```
 
@@ -923,7 +923,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "9330099904366966anonymous"
+	"id": "5098936157964886anonymous"
 }
 ```
 
@@ -997,7 +997,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "9330099904366966anonymous"
+	"id": "5098936157964886anonymous"
 }
 ```
 
@@ -1071,7 +1071,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			]
 		}
 	],
-	"id": "9330099904366966anonymous"
+	"id": "5098936157964886anonymous"
 }
 ```
 
@@ -1101,7 +1101,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 20
 		}
 	],
-	"id": "2685666441270165anonymous"
+	"id": "3907071356328604anonymous"
 }
 ```
 
@@ -1131,7 +1131,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 20
 		}
 	],
-	"id": "2685666441270165anonymous"
+	"id": "3907071356328604anonymous"
 }
 ```
 
@@ -1161,7 +1161,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 2
 		}
 	],
-	"id": "06559797817309088anonymous"
+	"id": "9213314070183267anonymous"
 }
 ```
 
@@ -1191,7 +1191,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 2
 		}
 	],
-	"id": "06559797817309088anonymous"
+	"id": "9213314070183267anonymous"
 }
 ```
 
@@ -1221,7 +1221,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 2
 		}
 	],
-	"id": "06559797817309088anonymous"
+	"id": "9213314070183267anonymous"
 }
 ```
 
@@ -1251,7 +1251,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 2
 		}
 	],
-	"id": "06559797817309088anonymous"
+	"id": "9213314070183267anonymous"
 }
 ```
 
@@ -1283,7 +1283,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minLength": 4
 		}
 	],
-	"id": "28640383555153615anonymous"
+	"id": "031419695103227285anonymous"
 }
 ```
 
@@ -1315,7 +1315,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minLength": 4
 		}
 	],
-	"id": "28640383555153615anonymous"
+	"id": "031419695103227285anonymous"
 }
 ```
 
@@ -1347,7 +1347,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minLength": 4
 		}
 	],
-	"id": "28640383555153615anonymous"
+	"id": "031419695103227285anonymous"
 }
 ```
 
@@ -1373,7 +1373,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"default": []
 		}
 	},
-	"id": "6488678074339513anonymous"
+	"id": "3417697864864473anonymous"
 }
 ```
 
@@ -1399,7 +1399,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"default": []
 		}
 	},
-	"id": "6488678074339513anonymous"
+	"id": "3417697864864473anonymous"
 }
 ```
 
@@ -1427,7 +1427,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"default": "bad"
 		}
 	},
-	"id": "32516693662514906anonymous"
+	"id": "71255214924049anonymous"
 }
 ```
 
@@ -1455,7 +1455,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"default": "bad"
 		}
 	},
-	"id": "32516693662514906anonymous"
+	"id": "71255214924049anonymous"
 }
 ```
 
@@ -1471,7 +1471,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"$ref": "http://json-schema.org/draft-04/schema#",
-	"id": "034325688246810815anonymous"
+	"id": "19734850893110378anonymous"
 }
 ```
 
@@ -1495,7 +1495,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"foo"
 		]
 	},
-	"id": "03652061948537044anonymous"
+	"id": "8471000369122379anonymous"
 }
 ```
 
@@ -1519,7 +1519,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"foo"
 		]
 	},
-	"id": "03652061948537044anonymous"
+	"id": "8471000369122379anonymous"
 }
 ```
 
@@ -1543,7 +1543,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"foo"
 		]
 	},
-	"id": "03652061948537044anonymous"
+	"id": "8471000369122379anonymous"
 }
 ```
 
@@ -1567,7 +1567,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"foo"
 		]
 	},
-	"id": "03652061948537044anonymous"
+	"id": "8471000369122379anonymous"
 }
 ```
 
@@ -1591,7 +1591,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"foo"
 		]
 	},
-	"id": "03652061948537044anonymous"
+	"id": "8471000369122379anonymous"
 }
 ```
 
@@ -1617,7 +1617,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"bar"
 		]
 	},
-	"id": "4384714866346111anonymous"
+	"id": "5961484550743417anonymous"
 }
 ```
 
@@ -1643,7 +1643,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"bar"
 		]
 	},
-	"id": "4384714866346111anonymous"
+	"id": "5961484550743417anonymous"
 }
 ```
 
@@ -1669,7 +1669,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"bar"
 		]
 	},
-	"id": "4384714866346111anonymous"
+	"id": "5961484550743417anonymous"
 }
 ```
 
@@ -1695,7 +1695,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"bar"
 		]
 	},
-	"id": "4384714866346111anonymous"
+	"id": "5961484550743417anonymous"
 }
 ```
 
@@ -1721,7 +1721,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"bar"
 		]
 	},
-	"id": "4384714866346111anonymous"
+	"id": "5961484550743417anonymous"
 }
 ```
 
@@ -1747,7 +1747,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"bar"
 		]
 	},
-	"id": "4384714866346111anonymous"
+	"id": "5961484550743417anonymous"
 }
 ```
 
@@ -1785,7 +1785,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			}
 		}
 	},
-	"id": "15518918534617798anonymous"
+	"id": "4868494847143856anonymous"
 }
 ```
 
@@ -1823,7 +1823,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			}
 		}
 	},
-	"id": "15518918534617798anonymous"
+	"id": "4868494847143856anonymous"
 }
 ```
 
@@ -1861,7 +1861,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			}
 		}
 	},
-	"id": "15518918534617798anonymous"
+	"id": "4868494847143856anonymous"
 }
 ```
 
@@ -1899,7 +1899,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			}
 		}
 	},
-	"id": "15518918534617798anonymous"
+	"id": "4868494847143856anonymous"
 }
 ```
 
@@ -1937,7 +1937,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			}
 		}
 	},
-	"id": "15518918534617798anonymous"
+	"id": "4868494847143856anonymous"
 }
 ```
 
@@ -1961,7 +1961,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		2,
 		3
 	],
-	"id": "26210542855688335anonymous"
+	"id": "25601212671855444anonymous"
 }
 ```
 
@@ -1985,7 +1985,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		2,
 		3
 	],
-	"id": "26210542855688335anonymous"
+	"id": "25601212671855444anonymous"
 }
 ```
 
@@ -2017,7 +2017,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"foo": 12
 		}
 	],
-	"id": "7067450260741102anonymous"
+	"id": "7368487743299854anonymous"
 }
 ```
 
@@ -2049,7 +2049,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"foo": 12
 		}
 	],
-	"id": "7067450260741102anonymous"
+	"id": "7368487743299854anonymous"
 }
 ```
 
@@ -2081,7 +2081,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"foo": 12
 		}
 	],
-	"id": "7067450260741102anonymous"
+	"id": "7368487743299854anonymous"
 }
 ```
 
@@ -2127,7 +2127,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"required": [
 		"bar"
 	],
-	"id": "5071188285457002anonymous"
+	"id": "7844277892947435anonymous"
 }
 ```
 
@@ -2173,7 +2173,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"required": [
 		"bar"
 	],
-	"id": "5071188285457002anonymous"
+	"id": "7844277892947435anonymous"
 }
 ```
 
@@ -2219,7 +2219,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"required": [
 		"bar"
 	],
-	"id": "5071188285457002anonymous"
+	"id": "7844277892947435anonymous"
 }
 ```
 
@@ -2265,7 +2265,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"required": [
 		"bar"
 	],
-	"id": "5071188285457002anonymous"
+	"id": "7844277892947435anonymous"
 }
 ```
 
@@ -2285,7 +2285,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"items": {
 		"type": "integer"
 	},
-	"id": "11227341735416063anonymous"
+	"id": "9332175300510299anonymous"
 }
 ```
 
@@ -2305,7 +2305,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"items": {
 		"type": "integer"
 	},
-	"id": "11227341735416063anonymous"
+	"id": "9332175300510299anonymous"
 }
 ```
 
@@ -2325,7 +2325,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"items": {
 		"type": "integer"
 	},
-	"id": "11227341735416063anonymous"
+	"id": "9332175300510299anonymous"
 }
 ```
 
@@ -2345,7 +2345,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"items": {
 		"type": "integer"
 	},
-	"id": "11227341735416063anonymous"
+	"id": "9332175300510299anonymous"
 }
 ```
 
@@ -2375,7 +2375,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	],
-	"id": "7261943363122094anonymous"
+	"id": "64272171028807anonymous"
 }
 ```
 
@@ -2405,7 +2405,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	],
-	"id": "7261943363122094anonymous"
+	"id": "64272171028807anonymous"
 }
 ```
 
@@ -2435,7 +2435,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	],
-	"id": "7261943363122094anonymous"
+	"id": "64272171028807anonymous"
 }
 ```
 
@@ -2465,7 +2465,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	],
-	"id": "7261943363122094anonymous"
+	"id": "64272171028807anonymous"
 }
 ```
 
@@ -2495,7 +2495,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	],
-	"id": "7261943363122094anonymous"
+	"id": "64272171028807anonymous"
 }
 ```
 
@@ -2525,7 +2525,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	],
-	"id": "7261943363122094anonymous"
+	"id": "64272171028807anonymous"
 }
 ```
 
@@ -2541,7 +2541,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxItems": 2,
-	"id": "373939246329297anonymous"
+	"id": "9400781648228691anonymous"
 }
 ```
 
@@ -2557,7 +2557,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxItems": 2,
-	"id": "373939246329297anonymous"
+	"id": "9400781648228691anonymous"
 }
 ```
 
@@ -2573,7 +2573,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxItems": 2,
-	"id": "373939246329297anonymous"
+	"id": "9400781648228691anonymous"
 }
 ```
 
@@ -2589,7 +2589,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxItems": 2,
-	"id": "373939246329297anonymous"
+	"id": "9400781648228691anonymous"
 }
 ```
 
@@ -2605,7 +2605,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxLength": 2,
-	"id": "04675208049611146anonymous"
+	"id": "05697251726045671anonymous"
 }
 ```
 
@@ -2621,7 +2621,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxLength": 2,
-	"id": "04675208049611146anonymous"
+	"id": "05697251726045671anonymous"
 }
 ```
 
@@ -2637,7 +2637,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxLength": 2,
-	"id": "04675208049611146anonymous"
+	"id": "05697251726045671anonymous"
 }
 ```
 
@@ -2653,7 +2653,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxLength": 2,
-	"id": "04675208049611146anonymous"
+	"id": "05697251726045671anonymous"
 }
 ```
 
@@ -2669,7 +2669,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxLength": 2,
-	"id": "04675208049611146anonymous"
+	"id": "05697251726045671anonymous"
 }
 ```
 
@@ -2685,7 +2685,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxProperties": 2,
-	"id": "6519724101476152anonymous"
+	"id": "024964926206112237anonymous"
 }
 ```
 
@@ -2701,7 +2701,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxProperties": 2,
-	"id": "6519724101476152anonymous"
+	"id": "024964926206112237anonymous"
 }
 ```
 
@@ -2717,7 +2717,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxProperties": 2,
-	"id": "6519724101476152anonymous"
+	"id": "024964926206112237anonymous"
 }
 ```
 
@@ -2733,7 +2733,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maxProperties": 2,
-	"id": "6519724101476152anonymous"
+	"id": "024964926206112237anonymous"
 }
 ```
 
@@ -2749,7 +2749,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maximum": 3,
-	"id": "753529626280401anonymous"
+	"id": "9837676300636817anonymous"
 }
 ```
 
@@ -2765,7 +2765,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maximum": 3,
-	"id": "753529626280401anonymous"
+	"id": "9837676300636817anonymous"
 }
 ```
 
@@ -2781,7 +2781,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maximum": 3,
-	"id": "753529626280401anonymous"
+	"id": "9837676300636817anonymous"
 }
 ```
 
@@ -2797,7 +2797,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maximum": 3,
-	"id": "753529626280401anonymous"
+	"id": "9837676300636817anonymous"
 }
 ```
 
@@ -2815,7 +2815,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"maximum": 3,
 	"exclusiveMaximum": true,
-	"id": "8868648749996633anonymous"
+	"id": "9714772608335254anonymous"
 }
 ```
 
@@ -2833,7 +2833,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"maximum": 3,
 	"exclusiveMaximum": true,
-	"id": "8868648749996633anonymous"
+	"id": "9714772608335254anonymous"
 }
 ```
 
@@ -2849,7 +2849,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minItems": 1,
-	"id": "33822474869524544anonymous"
+	"id": "9117020400869471anonymous"
 }
 ```
 
@@ -2865,7 +2865,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minItems": 1,
-	"id": "33822474869524544anonymous"
+	"id": "9117020400869471anonymous"
 }
 ```
 
@@ -2881,7 +2881,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minItems": 1,
-	"id": "33822474869524544anonymous"
+	"id": "9117020400869471anonymous"
 }
 ```
 
@@ -2897,7 +2897,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minItems": 1,
-	"id": "33822474869524544anonymous"
+	"id": "9117020400869471anonymous"
 }
 ```
 
@@ -2913,7 +2913,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minLength": 2,
-	"id": "8730073491722423anonymous"
+	"id": "01895118407030094anonymous"
 }
 ```
 
@@ -2929,7 +2929,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minLength": 2,
-	"id": "8730073491722423anonymous"
+	"id": "01895118407030094anonymous"
 }
 ```
 
@@ -2945,7 +2945,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minLength": 2,
-	"id": "8730073491722423anonymous"
+	"id": "01895118407030094anonymous"
 }
 ```
 
@@ -2961,7 +2961,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minLength": 2,
-	"id": "8730073491722423anonymous"
+	"id": "01895118407030094anonymous"
 }
 ```
 
@@ -2977,7 +2977,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minLength": 2,
-	"id": "8730073491722423anonymous"
+	"id": "01895118407030094anonymous"
 }
 ```
 
@@ -2993,7 +2993,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minProperties": 1,
-	"id": "6141140048805867anonymous"
+	"id": "07128799337976499anonymous"
 }
 ```
 
@@ -3009,7 +3009,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minProperties": 1,
-	"id": "6141140048805867anonymous"
+	"id": "07128799337976499anonymous"
 }
 ```
 
@@ -3025,7 +3025,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minProperties": 1,
-	"id": "6141140048805867anonymous"
+	"id": "07128799337976499anonymous"
 }
 ```
 
@@ -3041,7 +3041,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minProperties": 1,
-	"id": "6141140048805867anonymous"
+	"id": "07128799337976499anonymous"
 }
 ```
 
@@ -3057,7 +3057,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minimum": 1.1,
-	"id": "967972310061131anonymous"
+	"id": "9838919595535454anonymous"
 }
 ```
 
@@ -3073,7 +3073,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minimum": 1.1,
-	"id": "967972310061131anonymous"
+	"id": "9838919595535454anonymous"
 }
 ```
 
@@ -3089,7 +3089,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minimum": 1.1,
-	"id": "967972310061131anonymous"
+	"id": "9838919595535454anonymous"
 }
 ```
 
@@ -3105,7 +3105,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minimum": 1.1,
-	"id": "967972310061131anonymous"
+	"id": "9838919595535454anonymous"
 }
 ```
 
@@ -3123,7 +3123,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"minimum": 1.1,
 	"exclusiveMinimum": true,
-	"id": "42475677218191055anonymous"
+	"id": "3420367902260877anonymous"
 }
 ```
 
@@ -3141,7 +3141,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"minimum": 1.1,
 	"exclusiveMinimum": true,
-	"id": "42475677218191055anonymous"
+	"id": "3420367902260877anonymous"
 }
 ```
 
@@ -3157,7 +3157,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"multipleOf": 2,
-	"id": "791874584535317anonymous"
+	"id": "24553082882751065anonymous"
 }
 ```
 
@@ -3173,7 +3173,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"multipleOf": 2,
-	"id": "791874584535317anonymous"
+	"id": "24553082882751065anonymous"
 }
 ```
 
@@ -3189,7 +3189,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"multipleOf": 2,
-	"id": "791874584535317anonymous"
+	"id": "24553082882751065anonymous"
 }
 ```
 
@@ -3205,7 +3205,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"multipleOf": 1.5,
-	"id": "9046160606834266anonymous"
+	"id": "4846971550824386anonymous"
 }
 ```
 
@@ -3221,7 +3221,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"multipleOf": 1.5,
-	"id": "9046160606834266anonymous"
+	"id": "4846971550824386anonymous"
 }
 ```
 
@@ -3237,7 +3237,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"multipleOf": 1.5,
-	"id": "9046160606834266anonymous"
+	"id": "4846971550824386anonymous"
 }
 ```
 
@@ -3253,7 +3253,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"multipleOf": 0.0001,
-	"id": "866921213829293anonymous"
+	"id": "9161054395475656anonymous"
 }
 ```
 
@@ -3269,7 +3269,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"multipleOf": 0.0001,
-	"id": "866921213829293anonymous"
+	"id": "9161054395475656anonymous"
 }
 ```
 
@@ -3289,7 +3289,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"not": {
 		"type": "integer"
 	},
-	"id": "5928039671283098anonymous"
+	"id": "5962562739454611anonymous"
 }
 ```
 
@@ -3309,7 +3309,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"not": {
 		"type": "integer"
 	},
-	"id": "5928039671283098anonymous"
+	"id": "5962562739454611anonymous"
 }
 ```
 
@@ -3335,7 +3335,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"boolean"
 		]
 	},
-	"id": "08518556996797466anonymous"
+	"id": "22977501736200812anonymous"
 }
 ```
 
@@ -3361,7 +3361,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"boolean"
 		]
 	},
-	"id": "08518556996797466anonymous"
+	"id": "22977501736200812anonymous"
 }
 ```
 
@@ -3387,7 +3387,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"boolean"
 		]
 	},
-	"id": "08518556996797466anonymous"
+	"id": "22977501736200812anonymous"
 }
 ```
 
@@ -3417,7 +3417,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			}
 		}
 	},
-	"id": "4785077561239137anonymous"
+	"id": "44734368510911016anonymous"
 }
 ```
 
@@ -3447,7 +3447,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			}
 		}
 	},
-	"id": "4785077561239137anonymous"
+	"id": "44734368510911016anonymous"
 }
 ```
 
@@ -3477,7 +3477,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			}
 		}
 	},
-	"id": "4785077561239137anonymous"
+	"id": "44734368510911016anonymous"
 }
 ```
 
@@ -3501,7 +3501,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"not": {}
 		}
 	},
-	"id": "15242794235231583anonymous"
+	"id": "4697827999612385anonymous"
 }
 ```
 
@@ -3525,7 +3525,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"not": {}
 		}
 	},
-	"id": "15242794235231583anonymous"
+	"id": "4697827999612385anonymous"
 }
 ```
 
@@ -3555,7 +3555,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 2
 		}
 	],
-	"id": "7434188831011337anonymous"
+	"id": "0799840646875778anonymous"
 }
 ```
 
@@ -3585,7 +3585,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 2
 		}
 	],
-	"id": "7434188831011337anonymous"
+	"id": "0799840646875778anonymous"
 }
 ```
 
@@ -3615,7 +3615,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 2
 		}
 	],
-	"id": "7434188831011337anonymous"
+	"id": "0799840646875778anonymous"
 }
 ```
 
@@ -3645,7 +3645,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"minimum": 2
 		}
 	],
-	"id": "7434188831011337anonymous"
+	"id": "0799840646875778anonymous"
 }
 ```
 
@@ -3677,7 +3677,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maxLength": 4
 		}
 	],
-	"id": "4397593327847089anonymous"
+	"id": "5627052562931456anonymous"
 }
 ```
 
@@ -3709,7 +3709,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maxLength": 4
 		}
 	],
-	"id": "4397593327847089anonymous"
+	"id": "5627052562931456anonymous"
 }
 ```
 
@@ -3741,7 +3741,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maxLength": 4
 		}
 	],
-	"id": "4397593327847089anonymous"
+	"id": "5627052562931456anonymous"
 }
 ```
 
@@ -3757,7 +3757,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "0037054814014485515anonymous"
+	"id": "3533268109864509anonymous"
 }
 ```
 
@@ -3773,7 +3773,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "08032116213514762anonymous"
+	"id": "8244885420727166anonymous"
 }
 ```
 
@@ -3789,7 +3789,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "01694781586964811anonymous"
+	"id": "9984881418817309anonymous"
 }
 ```
 
@@ -3805,7 +3805,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "24107522670457748anonymous"
+	"id": "7761737544979725anonymous"
 }
 ```
 
@@ -3821,7 +3821,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "771952919851556anonymous"
+	"id": "019801168913551326anonymous"
 }
 ```
 
@@ -3837,7 +3837,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"maximum": 18446744073709552000,
-	"id": "7898762407861986anonymous"
+	"id": "4971580222650269anonymous"
 }
 ```
 
@@ -3855,7 +3855,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"maximum": 9.727837981879871e+26,
 	"exclusiveMaximum": true,
-	"id": "01290667105594756anonymous"
+	"id": "5668908272720712anonymous"
 }
 ```
 
@@ -3871,7 +3871,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"minimum": -18446744073709552000,
-	"id": "6772210263424245anonymous"
+	"id": "5419896130112591anonymous"
 }
 ```
 
@@ -3889,7 +3889,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"minimum": -9.727837981879871e+26,
 	"exclusiveMinimum": true,
-	"id": "7079495267992371anonymous"
+	"id": "523641400128755anonymous"
 }
 ```
 
@@ -3905,7 +3905,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "regex",
-	"id": "3711312229479238anonymous"
+	"id": "9584837073489698anonymous"
 }
 ```
 
@@ -3921,7 +3921,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "date-time",
-	"id": "044731900058126994anonymous"
+	"id": "1408211501768235anonymous"
 }
 ```
 
@@ -3937,7 +3937,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "date-time",
-	"id": "044731900058126994anonymous"
+	"id": "1408211501768235anonymous"
 }
 ```
 
@@ -3953,7 +3953,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "date-time",
-	"id": "044731900058126994anonymous"
+	"id": "1408211501768235anonymous"
 }
 ```
 
@@ -3969,7 +3969,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "uri",
-	"id": "9143623410920239anonymous"
+	"id": "38648340497992906anonymous"
 }
 ```
 
@@ -3985,7 +3985,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "uri",
-	"id": "9143623410920239anonymous"
+	"id": "38648340497992906anonymous"
 }
 ```
 
@@ -4001,7 +4001,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "uri",
-	"id": "9143623410920239anonymous"
+	"id": "38648340497992906anonymous"
 }
 ```
 
@@ -4017,7 +4017,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "uri",
-	"id": "9143623410920239anonymous"
+	"id": "38648340497992906anonymous"
 }
 ```
 
@@ -4033,7 +4033,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "email",
-	"id": "5366841741958794anonymous"
+	"id": "8948779810633811anonymous"
 }
 ```
 
@@ -4049,7 +4049,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "email",
-	"id": "5366841741958794anonymous"
+	"id": "8948779810633811anonymous"
 }
 ```
 
@@ -4065,7 +4065,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv4",
-	"id": "7938499051492891anonymous"
+	"id": "5398499848486409anonymous"
 }
 ```
 
@@ -4081,7 +4081,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv4",
-	"id": "7938499051492891anonymous"
+	"id": "5398499848486409anonymous"
 }
 ```
 
@@ -4097,7 +4097,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv4",
-	"id": "7938499051492891anonymous"
+	"id": "5398499848486409anonymous"
 }
 ```
 
@@ -4113,7 +4113,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv4",
-	"id": "7938499051492891anonymous"
+	"id": "5398499848486409anonymous"
 }
 ```
 
@@ -4129,7 +4129,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv4",
-	"id": "7938499051492891anonymous"
+	"id": "5398499848486409anonymous"
 }
 ```
 
@@ -4145,7 +4145,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv6",
-	"id": "9072056609644321anonymous"
+	"id": "9691938836806036anonymous"
 }
 ```
 
@@ -4161,7 +4161,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv6",
-	"id": "9072056609644321anonymous"
+	"id": "9691938836806036anonymous"
 }
 ```
 
@@ -4177,7 +4177,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv6",
-	"id": "9072056609644321anonymous"
+	"id": "9691938836806036anonymous"
 }
 ```
 
@@ -4193,7 +4193,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "ipv6",
-	"id": "9072056609644321anonymous"
+	"id": "9691938836806036anonymous"
 }
 ```
 
@@ -4209,7 +4209,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "hostname",
-	"id": "30557080643156276anonymous"
+	"id": "9883087228024341anonymous"
 }
 ```
 
@@ -4225,7 +4225,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "hostname",
-	"id": "30557080643156276anonymous"
+	"id": "9883087228024341anonymous"
 }
 ```
 
@@ -4241,7 +4241,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "hostname",
-	"id": "30557080643156276anonymous"
+	"id": "9883087228024341anonymous"
 }
 ```
 
@@ -4257,7 +4257,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"format": "hostname",
-	"id": "30557080643156276anonymous"
+	"id": "9883087228024341anonymous"
 }
 ```
 
@@ -4273,7 +4273,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "2876649383111338anonymous"
+	"id": "6989888359272314anonymous"
 }
 ```
 
@@ -4289,7 +4289,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"pattern": "^a*$",
-	"id": "4142775030350099anonymous"
+	"id": "8937346011524809anonymous"
 }
 ```
 
@@ -4305,7 +4305,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"pattern": "^a*$",
-	"id": "4142775030350099anonymous"
+	"id": "8937346011524809anonymous"
 }
 ```
 
@@ -4321,7 +4321,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"pattern": "^a*$",
-	"id": "4142775030350099anonymous"
+	"id": "8937346011524809anonymous"
 }
 ```
 
@@ -4337,7 +4337,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"pattern": "a+",
-	"id": "4544544779952562anonymous"
+	"id": "6941229693529505anonymous"
 }
 ```
 
@@ -4361,7 +4361,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "integer"
 		}
 	},
-	"id": "028854633848915068anonymous"
+	"id": "3964299589421567anonymous"
 }
 ```
 
@@ -4385,7 +4385,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "integer"
 		}
 	},
-	"id": "028854633848915068anonymous"
+	"id": "3964299589421567anonymous"
 }
 ```
 
@@ -4409,7 +4409,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "integer"
 		}
 	},
-	"id": "028854633848915068anonymous"
+	"id": "3964299589421567anonymous"
 }
 ```
 
@@ -4433,7 +4433,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "integer"
 		}
 	},
-	"id": "028854633848915068anonymous"
+	"id": "3964299589421567anonymous"
 }
 ```
 
@@ -4457,7 +4457,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "integer"
 		}
 	},
-	"id": "028854633848915068anonymous"
+	"id": "3964299589421567anonymous"
 }
 ```
 
@@ -4487,7 +4487,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maximum": 20
 		}
 	},
-	"id": "557288647071488anonymous"
+	"id": "07170097018889132anonymous"
 }
 ```
 
@@ -4517,7 +4517,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maximum": 20
 		}
 	},
-	"id": "557288647071488anonymous"
+	"id": "07170097018889132anonymous"
 }
 ```
 
@@ -4547,7 +4547,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maximum": 20
 		}
 	},
-	"id": "557288647071488anonymous"
+	"id": "07170097018889132anonymous"
 }
 ```
 
@@ -4577,7 +4577,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maximum": 20
 		}
 	},
-	"id": "557288647071488anonymous"
+	"id": "07170097018889132anonymous"
 }
 ```
 
@@ -4607,7 +4607,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maximum": 20
 		}
 	},
-	"id": "557288647071488anonymous"
+	"id": "07170097018889132anonymous"
 }
 ```
 
@@ -4637,7 +4637,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"maximum": 20
 		}
 	},
-	"id": "557288647071488anonymous"
+	"id": "07170097018889132anonymous"
 }
 ```
 
@@ -4667,7 +4667,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "6521804191172442anonymous"
+	"id": "5248826790689884anonymous"
 }
 ```
 
@@ -4697,7 +4697,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "6521804191172442anonymous"
+	"id": "5248826790689884anonymous"
 }
 ```
 
@@ -4727,7 +4727,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "6521804191172442anonymous"
+	"id": "5248826790689884anonymous"
 }
 ```
 
@@ -4757,7 +4757,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "6521804191172442anonymous"
+	"id": "5248826790689884anonymous"
 }
 ```
 
@@ -4787,7 +4787,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "9186970957731695anonymous"
+	"id": "9379426870919745anonymous"
 }
 ```
 
@@ -4817,7 +4817,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "9186970957731695anonymous"
+	"id": "9379426870919745anonymous"
 }
 ```
 
@@ -4847,7 +4847,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "9186970957731695anonymous"
+	"id": "9379426870919745anonymous"
 }
 ```
 
@@ -4877,7 +4877,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "9186970957731695anonymous"
+	"id": "9379426870919745anonymous"
 }
 ```
 
@@ -4907,7 +4907,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "9186970957731695anonymous"
+	"id": "9379426870919745anonymous"
 }
 ```
 
@@ -4955,7 +4955,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "integer"
 	},
-	"id": "9709294089906582anonymous"
+	"id": "1175374315397324anonymous"
 }
 ```
 
@@ -5003,7 +5003,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "integer"
 	},
-	"id": "9709294089906582anonymous"
+	"id": "1175374315397324anonymous"
 }
 ```
 
@@ -5051,7 +5051,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "integer"
 	},
-	"id": "9709294089906582anonymous"
+	"id": "1175374315397324anonymous"
 }
 ```
 
@@ -5099,7 +5099,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "integer"
 	},
-	"id": "9709294089906582anonymous"
+	"id": "1175374315397324anonymous"
 }
 ```
 
@@ -5147,7 +5147,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "integer"
 	},
-	"id": "9709294089906582anonymous"
+	"id": "1175374315397324anonymous"
 }
 ```
 
@@ -5195,7 +5195,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "integer"
 	},
-	"id": "9709294089906582anonymous"
+	"id": "1175374315397324anonymous"
 }
 ```
 
@@ -5243,7 +5243,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "integer"
 	},
-	"id": "9709294089906582anonymous"
+	"id": "1175374315397324anonymous"
 }
 ```
 
@@ -5291,7 +5291,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"additionalProperties": {
 		"type": "integer"
 	},
-	"id": "9709294089906582anonymous"
+	"id": "1175374315397324anonymous"
 }
 ```
 
@@ -5313,11 +5313,11 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"properties": {
 		"foo": {
-			"$ref": "6361042762562632anonymous#"
+			"$ref": "3557659493765133anonymous#"
 		}
 	},
 	"additionalProperties": false,
-	"id": "6361042762562632anonymous"
+	"id": "3557659493765133anonymous"
 }
 ```
 
@@ -5339,11 +5339,11 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"properties": {
 		"foo": {
-			"$ref": "6361042762562632anonymous#"
+			"$ref": "3557659493765133anonymous#"
 		}
 	},
 	"additionalProperties": false,
-	"id": "6361042762562632anonymous"
+	"id": "3557659493765133anonymous"
 }
 ```
 
@@ -5365,11 +5365,11 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"properties": {
 		"foo": {
-			"$ref": "6361042762562632anonymous#"
+			"$ref": "3557659493765133anonymous#"
 		}
 	},
 	"additionalProperties": false,
-	"id": "6361042762562632anonymous"
+	"id": "3557659493765133anonymous"
 }
 ```
 
@@ -5391,11 +5391,11 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"properties": {
 		"foo": {
-			"$ref": "6361042762562632anonymous#"
+			"$ref": "3557659493765133anonymous#"
 		}
 	},
 	"additionalProperties": false,
-	"id": "6361042762562632anonymous"
+	"id": "3557659493765133anonymous"
 }
 ```
 
@@ -5420,13 +5420,13 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"properties": {
 		"foo": {
 			"type": "integer",
-			"id": "41601243355933204anonymous#/properties/foo"
+			"id": "4331296958022277anonymous#/properties/foo"
 		},
 		"bar": {
-			"$ref": "41601243355933204anonymous#/properties/foo"
+			"$ref": "4331296958022277anonymous#/properties/foo"
 		}
 	},
-	"id": "41601243355933204anonymous"
+	"id": "4331296958022277anonymous"
 }
 ```
 
@@ -5451,13 +5451,13 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"properties": {
 		"foo": {
 			"type": "integer",
-			"id": "41601243355933204anonymous#/properties/foo"
+			"id": "4331296958022277anonymous#/properties/foo"
 		},
 		"bar": {
-			"$ref": "41601243355933204anonymous#/properties/foo"
+			"$ref": "4331296958022277anonymous#/properties/foo"
 		}
 	},
-	"id": "41601243355933204anonymous"
+	"id": "4331296958022277anonymous"
 }
 ```
 
@@ -5482,13 +5482,13 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"items": [
 		{
 			"type": "integer",
-			"id": "7177251625571466anonymous#/items/0"
+			"id": "6092112613187088anonymous#/items/0"
 		},
 		{
-			"$ref": "7177251625571466anonymous#/items/0"
+			"$ref": "6092112613187088anonymous#/items/0"
 		}
 	],
-	"id": "7177251625571466anonymous"
+	"id": "6092112613187088anonymous"
 }
 ```
 
@@ -5513,13 +5513,13 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"items": [
 		{
 			"type": "integer",
-			"id": "7177251625571466anonymous#/items/0"
+			"id": "6092112613187088anonymous#/items/0"
 		},
 		{
-			"$ref": "7177251625571466anonymous#/items/0"
+			"$ref": "6092112613187088anonymous#/items/0"
 		}
 	],
-	"id": "7177251625571466anonymous"
+	"id": "6092112613187088anonymous"
 }
 ```
 
@@ -5555,28 +5555,28 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"tilda~field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/tilda~0field"
+		"id": "6275933757969603anonymous#/tilda~0field"
 	},
 	"slash/field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/slash~1field"
+		"id": "6275933757969603anonymous#/slash~1field"
 	},
 	"percent%field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/percent%25field"
+		"id": "6275933757969603anonymous#/percent%25field"
 	},
 	"properties": {
 		"tilda": {
-			"$ref": "7953604718817873anonymous#/tilda~0field"
+			"$ref": "6275933757969603anonymous#/tilda~0field"
 		},
 		"slash": {
-			"$ref": "7953604718817873anonymous#/slash~1field"
+			"$ref": "6275933757969603anonymous#/slash~1field"
 		},
 		"percent": {
-			"$ref": "7953604718817873anonymous#/percent%25field"
+			"$ref": "6275933757969603anonymous#/percent%25field"
 		}
 	},
-	"id": "7953604718817873anonymous"
+	"id": "6275933757969603anonymous"
 }
 ```
 
@@ -5612,28 +5612,28 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"tilda~field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/tilda~0field"
+		"id": "6275933757969603anonymous#/tilda~0field"
 	},
 	"slash/field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/slash~1field"
+		"id": "6275933757969603anonymous#/slash~1field"
 	},
 	"percent%field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/percent%25field"
+		"id": "6275933757969603anonymous#/percent%25field"
 	},
 	"properties": {
 		"tilda": {
-			"$ref": "7953604718817873anonymous#/tilda~0field"
+			"$ref": "6275933757969603anonymous#/tilda~0field"
 		},
 		"slash": {
-			"$ref": "7953604718817873anonymous#/slash~1field"
+			"$ref": "6275933757969603anonymous#/slash~1field"
 		},
 		"percent": {
-			"$ref": "7953604718817873anonymous#/percent%25field"
+			"$ref": "6275933757969603anonymous#/percent%25field"
 		}
 	},
-	"id": "7953604718817873anonymous"
+	"id": "6275933757969603anonymous"
 }
 ```
 
@@ -5669,28 +5669,28 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"tilda~field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/tilda~0field"
+		"id": "6275933757969603anonymous#/tilda~0field"
 	},
 	"slash/field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/slash~1field"
+		"id": "6275933757969603anonymous#/slash~1field"
 	},
 	"percent%field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/percent%25field"
+		"id": "6275933757969603anonymous#/percent%25field"
 	},
 	"properties": {
 		"tilda": {
-			"$ref": "7953604718817873anonymous#/tilda~0field"
+			"$ref": "6275933757969603anonymous#/tilda~0field"
 		},
 		"slash": {
-			"$ref": "7953604718817873anonymous#/slash~1field"
+			"$ref": "6275933757969603anonymous#/slash~1field"
 		},
 		"percent": {
-			"$ref": "7953604718817873anonymous#/percent%25field"
+			"$ref": "6275933757969603anonymous#/percent%25field"
 		}
 	},
-	"id": "7953604718817873anonymous"
+	"id": "6275933757969603anonymous"
 }
 ```
 
@@ -5726,28 +5726,28 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"tilda~field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/tilda~0field"
+		"id": "6275933757969603anonymous#/tilda~0field"
 	},
 	"slash/field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/slash~1field"
+		"id": "6275933757969603anonymous#/slash~1field"
 	},
 	"percent%field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/percent%25field"
+		"id": "6275933757969603anonymous#/percent%25field"
 	},
 	"properties": {
 		"tilda": {
-			"$ref": "7953604718817873anonymous#/tilda~0field"
+			"$ref": "6275933757969603anonymous#/tilda~0field"
 		},
 		"slash": {
-			"$ref": "7953604718817873anonymous#/slash~1field"
+			"$ref": "6275933757969603anonymous#/slash~1field"
 		},
 		"percent": {
-			"$ref": "7953604718817873anonymous#/percent%25field"
+			"$ref": "6275933757969603anonymous#/percent%25field"
 		}
 	},
-	"id": "7953604718817873anonymous"
+	"id": "6275933757969603anonymous"
 }
 ```
 
@@ -5783,28 +5783,28 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"tilda~field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/tilda~0field"
+		"id": "6275933757969603anonymous#/tilda~0field"
 	},
 	"slash/field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/slash~1field"
+		"id": "6275933757969603anonymous#/slash~1field"
 	},
 	"percent%field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/percent%25field"
+		"id": "6275933757969603anonymous#/percent%25field"
 	},
 	"properties": {
 		"tilda": {
-			"$ref": "7953604718817873anonymous#/tilda~0field"
+			"$ref": "6275933757969603anonymous#/tilda~0field"
 		},
 		"slash": {
-			"$ref": "7953604718817873anonymous#/slash~1field"
+			"$ref": "6275933757969603anonymous#/slash~1field"
 		},
 		"percent": {
-			"$ref": "7953604718817873anonymous#/percent%25field"
+			"$ref": "6275933757969603anonymous#/percent%25field"
 		}
 	},
-	"id": "7953604718817873anonymous"
+	"id": "6275933757969603anonymous"
 }
 ```
 
@@ -5840,28 +5840,28 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 {
 	"tilda~field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/tilda~0field"
+		"id": "6275933757969603anonymous#/tilda~0field"
 	},
 	"slash/field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/slash~1field"
+		"id": "6275933757969603anonymous#/slash~1field"
 	},
 	"percent%field": {
 		"type": "integer",
-		"id": "7953604718817873anonymous#/percent%25field"
+		"id": "6275933757969603anonymous#/percent%25field"
 	},
 	"properties": {
 		"tilda": {
-			"$ref": "7953604718817873anonymous#/tilda~0field"
+			"$ref": "6275933757969603anonymous#/tilda~0field"
 		},
 		"slash": {
-			"$ref": "7953604718817873anonymous#/slash~1field"
+			"$ref": "6275933757969603anonymous#/slash~1field"
 		},
 		"percent": {
-			"$ref": "7953604718817873anonymous#/percent%25field"
+			"$ref": "6275933757969603anonymous#/percent%25field"
 		}
 	},
-	"id": "7953604718817873anonymous"
+	"id": "6275933757969603anonymous"
 }
 ```
 
@@ -5892,14 +5892,14 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "integer"
 		},
 		"b": {
-			"$ref": "21418891893988068anonymous#/definitions/a"
+			"$ref": "6187115487599144anonymous#/definitions/a"
 		},
 		"c": {
-			"$ref": "21418891893988068anonymous#/definitions/b"
+			"$ref": "6187115487599144anonymous#/definitions/b"
 		}
 	},
-	"$ref": "21418891893988068anonymous#/definitions/c",
-	"id": "21418891893988068anonymous"
+	"$ref": "6187115487599144anonymous#/definitions/c",
+	"id": "6187115487599144anonymous"
 }
 ```
 
@@ -5930,14 +5930,14 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "integer"
 		},
 		"b": {
-			"$ref": "21418891893988068anonymous#/definitions/a"
+			"$ref": "6187115487599144anonymous#/definitions/a"
 		},
 		"c": {
-			"$ref": "21418891893988068anonymous#/definitions/b"
+			"$ref": "6187115487599144anonymous#/definitions/b"
 		}
 	},
-	"$ref": "21418891893988068anonymous#/definitions/c",
-	"id": "21418891893988068anonymous"
+	"$ref": "6187115487599144anonymous#/definitions/c",
+	"id": "6187115487599144anonymous"
 }
 ```
 
@@ -5965,16 +5965,16 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"definitions": {
 		"reffed": {
 			"type": "array",
-			"id": "1540700398372883anonymous#/definitions/reffed"
+			"id": "9411622386566862anonymous#/definitions/reffed"
 		}
 	},
 	"properties": {
 		"foo": {
-			"$ref": "1540700398372883anonymous#/definitions/reffed",
+			"$ref": "9411622386566862anonymous#/definitions/reffed",
 			"maxItems": 2
 		}
 	},
-	"id": "1540700398372883anonymous"
+	"id": "9411622386566862anonymous"
 }
 ```
 
@@ -6002,16 +6002,16 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"definitions": {
 		"reffed": {
 			"type": "array",
-			"id": "1540700398372883anonymous#/definitions/reffed"
+			"id": "9411622386566862anonymous#/definitions/reffed"
 		}
 	},
 	"properties": {
 		"foo": {
-			"$ref": "1540700398372883anonymous#/definitions/reffed",
+			"$ref": "9411622386566862anonymous#/definitions/reffed",
 			"maxItems": 2
 		}
 	},
-	"id": "1540700398372883anonymous"
+	"id": "9411622386566862anonymous"
 }
 ```
 
@@ -6039,16 +6039,16 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"definitions": {
 		"reffed": {
 			"type": "array",
-			"id": "1540700398372883anonymous#/definitions/reffed"
+			"id": "9411622386566862anonymous#/definitions/reffed"
 		}
 	},
 	"properties": {
 		"foo": {
-			"$ref": "1540700398372883anonymous#/definitions/reffed",
+			"$ref": "9411622386566862anonymous#/definitions/reffed",
 			"maxItems": 2
 		}
 	},
-	"id": "1540700398372883anonymous"
+	"id": "9411622386566862anonymous"
 }
 ```
 
@@ -6064,7 +6064,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"$ref": "http://json-schema.org/draft-04/schema#",
-	"id": "8955974957584081anonymous"
+	"id": "01914077444834139anonymous"
 }
 ```
 
@@ -6080,7 +6080,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"$ref": "http://json-schema.org/draft-04/schema#",
-	"id": "8955974957584081anonymous"
+	"id": "01914077444834139anonymous"
 }
 ```
 
@@ -6104,7 +6104,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "5729992019048362anonymous"
+	"id": "7604554073184433anonymous"
 }
 ```
 
@@ -6128,7 +6128,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 			"type": "string"
 		}
 	},
-	"id": "5729992019048362anonymous"
+	"id": "7604554073184433anonymous"
 }
 ```
 
@@ -6144,7 +6144,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"$ref": "http://localhost:1234/subSchemas.json#/refToInteger",
-	"id": "684634896714696anonymous"
+	"id": "13496086090412618anonymous"
 }
 ```
 
@@ -6160,7 +6160,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"$ref": "http://localhost:1234/subSchemas.json#/refToInteger",
-	"id": "684634896714696anonymous"
+	"id": "13496086090412618anonymous"
 }
 ```
 
@@ -6386,7 +6386,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"required": [
 		"foo"
 	],
-	"id": "7091571278806594anonymous"
+	"id": "37954958191535626anonymous"
 }
 ```
 
@@ -6414,7 +6414,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"required": [
 		"foo"
 	],
-	"id": "7091571278806594anonymous"
+	"id": "37954958191535626anonymous"
 }
 ```
 
@@ -6442,7 +6442,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"required": [
 		"foo"
 	],
-	"id": "7091571278806594anonymous"
+	"id": "37954958191535626anonymous"
 }
 ```
 
@@ -6462,7 +6462,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 	"properties": {
 		"foo": {}
 	},
-	"id": "49998528825836774anonymous"
+	"id": "5635500479291762anonymous"
 }
 ```
 
@@ -6478,7 +6478,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "44515959657536275anonymous"
+	"id": "3151010425843679anonymous"
 }
 ```
 
@@ -6494,7 +6494,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "44515959657536275anonymous"
+	"id": "3151010425843679anonymous"
 }
 ```
 
@@ -6510,7 +6510,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "44515959657536275anonymous"
+	"id": "3151010425843679anonymous"
 }
 ```
 
@@ -6526,7 +6526,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "44515959657536275anonymous"
+	"id": "3151010425843679anonymous"
 }
 ```
 
@@ -6542,7 +6542,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "44515959657536275anonymous"
+	"id": "3151010425843679anonymous"
 }
 ```
 
@@ -6558,7 +6558,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "44515959657536275anonymous"
+	"id": "3151010425843679anonymous"
 }
 ```
 
@@ -6574,7 +6574,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "44515959657536275anonymous"
+	"id": "3151010425843679anonymous"
 }
 ```
 
@@ -6590,7 +6590,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "integer",
-	"id": "44515959657536275anonymous"
+	"id": "3151010425843679anonymous"
 }
 ```
 
@@ -6606,7 +6606,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "7193770825292642anonymous"
+	"id": "3917650847904579anonymous"
 }
 ```
 
@@ -6622,7 +6622,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "7193770825292642anonymous"
+	"id": "3917650847904579anonymous"
 }
 ```
 
@@ -6638,7 +6638,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "7193770825292642anonymous"
+	"id": "3917650847904579anonymous"
 }
 ```
 
@@ -6654,7 +6654,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "7193770825292642anonymous"
+	"id": "3917650847904579anonymous"
 }
 ```
 
@@ -6670,7 +6670,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "7193770825292642anonymous"
+	"id": "3917650847904579anonymous"
 }
 ```
 
@@ -6686,7 +6686,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "7193770825292642anonymous"
+	"id": "3917650847904579anonymous"
 }
 ```
 
@@ -6702,7 +6702,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "7193770825292642anonymous"
+	"id": "3917650847904579anonymous"
 }
 ```
 
@@ -6718,7 +6718,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "number",
-	"id": "7193770825292642anonymous"
+	"id": "3917650847904579anonymous"
 }
 ```
 
@@ -6734,7 +6734,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "6851006942210156anonymous"
+	"id": "387671777343628anonymous"
 }
 ```
 
@@ -6750,7 +6750,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "6851006942210156anonymous"
+	"id": "387671777343628anonymous"
 }
 ```
 
@@ -6766,7 +6766,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "6851006942210156anonymous"
+	"id": "387671777343628anonymous"
 }
 ```
 
@@ -6782,7 +6782,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "6851006942210156anonymous"
+	"id": "387671777343628anonymous"
 }
 ```
 
@@ -6798,7 +6798,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "6851006942210156anonymous"
+	"id": "387671777343628anonymous"
 }
 ```
 
@@ -6814,7 +6814,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "6851006942210156anonymous"
+	"id": "387671777343628anonymous"
 }
 ```
 
@@ -6830,7 +6830,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "6851006942210156anonymous"
+	"id": "387671777343628anonymous"
 }
 ```
 
@@ -6846,7 +6846,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "string",
-	"id": "6851006942210156anonymous"
+	"id": "387671777343628anonymous"
 }
 ```
 
@@ -6862,7 +6862,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "object",
-	"id": "3478690836424745anonymous"
+	"id": "5887089186881291anonymous"
 }
 ```
 
@@ -6878,7 +6878,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "object",
-	"id": "3478690836424745anonymous"
+	"id": "5887089186881291anonymous"
 }
 ```
 
@@ -6894,7 +6894,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "object",
-	"id": "3478690836424745anonymous"
+	"id": "5887089186881291anonymous"
 }
 ```
 
@@ -6910,7 +6910,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "object",
-	"id": "3478690836424745anonymous"
+	"id": "5887089186881291anonymous"
 }
 ```
 
@@ -6926,7 +6926,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "object",
-	"id": "3478690836424745anonymous"
+	"id": "5887089186881291anonymous"
 }
 ```
 
@@ -6942,7 +6942,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "object",
-	"id": "3478690836424745anonymous"
+	"id": "5887089186881291anonymous"
 }
 ```
 
@@ -6958,7 +6958,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "object",
-	"id": "3478690836424745anonymous"
+	"id": "5887089186881291anonymous"
 }
 ```
 
@@ -6974,7 +6974,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "array",
-	"id": "20427507855088423anonymous"
+	"id": "9120987921133044anonymous"
 }
 ```
 
@@ -6990,7 +6990,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "array",
-	"id": "20427507855088423anonymous"
+	"id": "9120987921133044anonymous"
 }
 ```
 
@@ -7006,7 +7006,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "array",
-	"id": "20427507855088423anonymous"
+	"id": "9120987921133044anonymous"
 }
 ```
 
@@ -7022,7 +7022,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "array",
-	"id": "20427507855088423anonymous"
+	"id": "9120987921133044anonymous"
 }
 ```
 
@@ -7038,7 +7038,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "array",
-	"id": "20427507855088423anonymous"
+	"id": "9120987921133044anonymous"
 }
 ```
 
@@ -7054,7 +7054,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "array",
-	"id": "20427507855088423anonymous"
+	"id": "9120987921133044anonymous"
 }
 ```
 
@@ -7070,7 +7070,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "array",
-	"id": "20427507855088423anonymous"
+	"id": "9120987921133044anonymous"
 }
 ```
 
@@ -7086,7 +7086,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "boolean",
-	"id": "069561627764678anonymous"
+	"id": "9480431847235511anonymous"
 }
 ```
 
@@ -7102,7 +7102,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "boolean",
-	"id": "069561627764678anonymous"
+	"id": "9480431847235511anonymous"
 }
 ```
 
@@ -7118,7 +7118,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "boolean",
-	"id": "069561627764678anonymous"
+	"id": "9480431847235511anonymous"
 }
 ```
 
@@ -7134,7 +7134,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "boolean",
-	"id": "069561627764678anonymous"
+	"id": "9480431847235511anonymous"
 }
 ```
 
@@ -7150,7 +7150,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "boolean",
-	"id": "069561627764678anonymous"
+	"id": "9480431847235511anonymous"
 }
 ```
 
@@ -7166,7 +7166,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "boolean",
-	"id": "069561627764678anonymous"
+	"id": "9480431847235511anonymous"
 }
 ```
 
@@ -7182,7 +7182,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "boolean",
-	"id": "069561627764678anonymous"
+	"id": "9480431847235511anonymous"
 }
 ```
 
@@ -7198,7 +7198,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "null",
-	"id": "08294188564977012anonymous"
+	"id": "6564653690159834anonymous"
 }
 ```
 
@@ -7214,7 +7214,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "null",
-	"id": "08294188564977012anonymous"
+	"id": "6564653690159834anonymous"
 }
 ```
 
@@ -7230,7 +7230,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "null",
-	"id": "08294188564977012anonymous"
+	"id": "6564653690159834anonymous"
 }
 ```
 
@@ -7246,7 +7246,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "null",
-	"id": "08294188564977012anonymous"
+	"id": "6564653690159834anonymous"
 }
 ```
 
@@ -7262,7 +7262,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "null",
-	"id": "08294188564977012anonymous"
+	"id": "6564653690159834anonymous"
 }
 ```
 
@@ -7278,7 +7278,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "null",
-	"id": "08294188564977012anonymous"
+	"id": "6564653690159834anonymous"
 }
 ```
 
@@ -7294,7 +7294,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"type": "null",
-	"id": "08294188564977012anonymous"
+	"id": "6564653690159834anonymous"
 }
 ```
 
@@ -7316,7 +7316,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"integer",
 		"string"
 	],
-	"id": "3770244854702298anonymous"
+	"id": "3105173830732908anonymous"
 }
 ```
 
@@ -7338,7 +7338,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"integer",
 		"string"
 	],
-	"id": "3770244854702298anonymous"
+	"id": "3105173830732908anonymous"
 }
 ```
 
@@ -7360,7 +7360,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"integer",
 		"string"
 	],
-	"id": "3770244854702298anonymous"
+	"id": "3105173830732908anonymous"
 }
 ```
 
@@ -7382,7 +7382,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"integer",
 		"string"
 	],
-	"id": "3770244854702298anonymous"
+	"id": "3105173830732908anonymous"
 }
 ```
 
@@ -7404,7 +7404,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"integer",
 		"string"
 	],
-	"id": "3770244854702298anonymous"
+	"id": "3105173830732908anonymous"
 }
 ```
 
@@ -7426,7 +7426,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"integer",
 		"string"
 	],
-	"id": "3770244854702298anonymous"
+	"id": "3105173830732908anonymous"
 }
 ```
 
@@ -7448,7 +7448,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 		"integer",
 		"string"
 	],
-	"id": "3770244854702298anonymous"
+	"id": "3105173830732908anonymous"
 }
 ```
 
@@ -7464,7 +7464,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7480,7 +7480,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7496,7 +7496,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7512,7 +7512,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7528,7 +7528,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7544,7 +7544,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7560,7 +7560,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7576,7 +7576,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7592,7 +7592,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7608,7 +7608,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7624,7 +7624,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7640,7 +7640,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 
@@ -7656,7 +7656,7 @@ When running tests [`json-model`](https://github.com/geraintluff/json-model) mut
 ```js
 {
 	"uniqueItems": true,
-	"id": "7079866910297636anonymous"
+	"id": "8985710431014915anonymous"
 }
 ```
 

--- a/reports/json-model.md
+++ b/reports/json-model.md
@@ -1,8 +1,5 @@
 # [`json-model`](https://github.com/geraintluff/json-model) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`json-model`](https://github.com/geraintluff/json-model) failed tests
 
@@ -40,6 +37,7 @@ that is the case for these tests.
 |`validation of host names, a host name starting with an illegal character`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name containing illegal characters`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name with a component too long`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`remote ref, containing refs itself, remote ref invalid`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, valid tree`|The schema failed to load(`Requests not enabled - try JsonModel.setRequestFunction(func): {"method":"GET","url":"http://localhost:1234/node"}`)
 |`Recursive references between schemas, invalid tree`|The schema failed to load(`Requests not enabled - try JsonModel.setRequestFunction(func): {"method":"GET","url":"http://localhost:1234/node"}`)

--- a/reports/json-schema-validator-generator.md
+++ b/reports/json-schema-validator-generator.md
@@ -1,8 +1,5 @@
 # json-schema-validator-generator - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # json-schema-validator-generator failed tests
 
@@ -11,36 +8,165 @@ that is the case for these tests.
 
 |test failed|reason
 |-----------|------
-|`invalid definition, invalid definition schema`|Expected result: `false` but validator returned: `true`
+|`additionalItems as schema, additional items match schema`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`items is schema, no additionalItems, all items match schema`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`array of items with no additionalItems, fewer number of items present`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`array of items with no additionalItems, equal number of items present`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalItems as false without items, items defaults to empty schema so everything is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalItems as false without items, ignores non-arrays`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalItems are allowed by default, only the first item is validated`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalProperties being false does not allow other properties, no additional properties is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalProperties being false does not allow other properties, ignores non-objects`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalProperties being false does not allow other properties, patternProperties are not additional properties`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalProperties allows a schema which should validate, no additional properties is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalProperties allows a schema which should validate, an additional valid property is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalProperties can exist by itself, an additional valid property is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`additionalProperties are allowed by default, additional properties are allowed`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`allOf, allOf`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`allOf with base schema, valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`allOf simple types, valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`anyOf, first anyOf valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`anyOf, second anyOf valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`anyOf, both anyOf valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`anyOf with base schema, one anyOf valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`invalid type for default, valid when property is specified`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`invalid type for default, still valid when the invalid default is used`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`invalid string value for default, valid when property is specified`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`invalid string value for default, still valid when the invalid default is used`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`valid definition, valid definition schema`|Expected result: `true` but validator returned: `false`
+|`dependencies, neither`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`dependencies, nondependant`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`dependencies, with dependency`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`dependencies, ignores non-objects`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple dependencies, neither`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple dependencies, nondependants`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple dependencies, with dependencies`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple dependencies subschema, valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple dependencies subschema, no dependency`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`simple enum validation, one of the enum is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`heterogeneous enum validation, one of the enum is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`enums in properties, both properties are valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`enums in properties, missing optional property is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`a schema given for items, valid items`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`a schema given for items, ignores non-arrays`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`a schema given for items, JavaScript pseudo-array is valid`|Expected result: `true` but validator returned: `false`
+|`an array of schemas for items, correct types`|Expected result: `true` but validator returned: `false`
+|`an array of schemas for items, incomplete array of items`|Expected result: `true` but validator returned: `false`
+|`an array of schemas for items, array with additional items`|Expected result: `true` but validator returned: `false`
+|`an array of schemas for items, empty array`|Expected result: `true` but validator returned: `false`
 |`an array of schemas for items, JavaScript pseudo-array is valid`|Expected result: `true` but validator returned: `false`
+|`maxItems validation, shorter is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maxItems validation, exact length is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maxItems validation, ignores non-arrays`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maxLength validation, shorter is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maxLength validation, exact length is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maxLength validation, ignores non-strings`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
 |`maxLength validation, two supplementary Unicode code points is long enough`|Expected result: `true` but validator returned: `false`
-|`minLength validation, one supplementary Unicode code point is not long enough`|Expected result: `false` but validator returned: `true`
-|`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
-|`validation of date-time strings, an invalid date-time string`|Expected result: `false` but validator returned: `true`
-|`validation of date-time strings, only RFC3339 not all of ISO 8601 are valid`|Expected result: `false` but validator returned: `true`
-|`validation of URIs, an invalid protocol-relative URI Reference`|Expected result: `false` but validator returned: `true`
-|`validation of URIs, an invalid URI`|Expected result: `false` but validator returned: `true`
-|`validation of URIs, an invalid URI though valid URI reference`|Expected result: `false` but validator returned: `true`
-|`validation of e-mail addresses, an invalid e-mail address`|Expected result: `false` but validator returned: `true`
-|`validation of IP addresses, an IP address with too many components`|Expected result: `false` but validator returned: `true`
-|`validation of IP addresses, an IP address with out-of-range values`|Expected result: `false` but validator returned: `true`
-|`validation of IP addresses, an IP address without 4 components`|Expected result: `false` but validator returned: `true`
-|`validation of IP addresses, an IP address as an integer`|Expected result: `false` but validator returned: `true`
-|`validation of IPv6 addresses, an IPv6 address with out-of-range values`|Expected result: `false` but validator returned: `true`
-|`validation of IPv6 addresses, an IPv6 address with too many components`|Expected result: `false` but validator returned: `true`
-|`validation of IPv6 addresses, an IPv6 address containing illegal characters`|Expected result: `false` but validator returned: `true`
-|`validation of host names, a host name starting with an illegal character`|Expected result: `false` but validator returned: `true`
-|`validation of host names, a host name containing illegal characters`|Expected result: `false` but validator returned: `true`
-|`validation of host names, a host name with a component too long`|Expected result: `false` but validator returned: `true`
-|`remote ref, containing refs itself, remote ref invalid`|Expected result: `false` but validator returned: `true`
-|`Recursive references between schemas, invalid tree`|Expected result: `false` but validator returned: `true`
-|`remote ref, remote ref invalid`|Expected result: `false` but validator returned: `true`
-|`fragment within remote ref, remote fragment invalid`|Expected result: `false` but validator returned: `true`
-|`ref within remote ref, ref within ref invalid`|Expected result: `false` but validator returned: `true`
-|`base URI change, base URI change ref invalid`|Expected result: `false` but validator returned: `true`
-|`base URI change - change folder, string is invalid`|Expected result: `false` but validator returned: `true`
-|`base URI change - change folder in subschema, string is invalid`|Expected result: `false` but validator returned: `true`
-|`root ref in remote ref, object is invalid`|Expected result: `false` but validator returned: `true`
+|`maxProperties validation, shorter is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maxProperties validation, exact length is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maxProperties validation, ignores non-objects`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maximum validation, below the maximum is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maximum validation, boundary point is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`maximum validation, ignores non-numbers`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`exclusiveMaximum validation, below the maximum is still valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minItems validation, longer is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minItems validation, exact length is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minItems validation, ignores non-arrays`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minLength validation, longer is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minLength validation, exact length is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minLength validation, ignores non-strings`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minProperties validation, longer is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minProperties validation, exact length is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minProperties validation, ignores non-objects`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minimum validation, above the minimum is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minimum validation, boundary point is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`minimum validation, ignores non-numbers`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`exclusiveMinimum validation, above the minimum is still valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`by int, int by int`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`by int, ignores non-numbers`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`by number, zero is multiple of anything`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`by number, 4.5 is multiple of 1.5`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`by small number, 0.0075 is multiple of 0.0001`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`not, allowed`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`not multiple types, valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`not more complex schema, match`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`not more complex schema, other match`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`forbidden property, property absent`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`oneOf, first oneOf valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`oneOf, second oneOf valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`oneOf with base schema, one oneOf valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`integer, a bignum is an integer`|Expected result: `true` but validator returned: `false`
+|`number, a bignum is a number`|Expected result: `true` but validator returned: `false`
+|`integer, a negative bignum is an integer`|Expected result: `true` but validator returned: `false`
+|`number, a negative bignum is a number`|Expected result: `true` but validator returned: `false`
+|`integer comparison, comparison works for high numbers`|Expected result: `true` but validator returned: `false`
+|`integer comparison, comparison works for very negative numbers`|Expected result: `true` but validator returned: `false`
+|`validation of date-time strings, a valid date-time string`|Expected result: `true` but validator returned: `false`
+|`validation of URIs, a valid URI`|Expected result: `true` but validator returned: `false`
+|`validation of e-mail addresses, a valid e-mail address`|Expected result: `true` but validator returned: `false`
+|`validation of IP addresses, a valid IP address`|Expected result: `true` but validator returned: `false`
+|`validation of IPv6 addresses, a valid IPv6 address`|Expected result: `true` but validator returned: `false`
+|`validation of host names, a valid host name`|Expected result: `true` but validator returned: `false`
+|`pattern validation, a matching pattern is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`pattern validation, ignores non-strings`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`pattern is not anchored, matches a substring`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`patternProperties validates properties matching a regex, a single valid match is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`patternProperties validates properties matching a regex, multiple valid matches is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`patternProperties validates properties matching a regex, ignores non-objects`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple simultaneous patternProperties are validated, a single valid match is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple simultaneous patternProperties are validated, a simultaneous match is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple simultaneous patternProperties are validated, multiple matches is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`regexes are not anchored by default and are case sensitive, non recognized members are ignored`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`regexes are not anchored by default and are case sensitive, regexes are case sensitive`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`object properties validation, both properties present and valid is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`object properties validation, doesn't invalidate other properties`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`object properties validation, ignores non-objects`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`properties, patternProperties, additionalProperties interaction, property validates property`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`properties, patternProperties, additionalProperties interaction, patternProperty validates nonproperty`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`properties, patternProperties, additionalProperties interaction, additionalProperty ignores property`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`properties, patternProperties, additionalProperties interaction, additionalProperty validates others`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`root pointer ref, match`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`root pointer ref, recursive match`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`relative pointer ref to object, match`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`relative pointer ref to array, match array`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`escaped pointer ref, slash valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`escaped pointer ref, tilda valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`escaped pointer ref, percent valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`nested refs, nested ref valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`ref overrides any sibling keywords, ref valid`|Expected result: `true` but validator returned: `false`
+|`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
+|`remote ref, containing refs itself, remote ref valid`|Expected result: `true` but validator returned: `false`
+|`property named $ref that is not a reference, property named $ref valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`Recursive references between schemas, valid tree`|Expected result: `true` but validator returned: `false`
+|`remote ref, remote ref valid`|Expected result: `true` but validator returned: `false`
+|`fragment within remote ref, remote fragment valid`|Expected result: `true` but validator returned: `false`
+|`ref within remote ref, ref within ref valid`|Expected result: `true` but validator returned: `false`
+|`base URI change, base URI change ref valid`|Expected result: `true` but validator returned: `false`
+|`base URI change - change folder, number is valid`|Expected result: `true` but validator returned: `false`
+|`base URI change - change folder in subschema, number is valid`|Expected result: `true` but validator returned: `false`
+|`root ref in remote ref, string is valid`|Expected result: `true` but validator returned: `false`
+|`root ref in remote ref, null is valid`|Expected result: `true` but validator returned: `false`
+|`required validation, present required property is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`required validation, ignores non-objects`|Expected result: `true` but validator returned: `false`
+|`required default validation, not required by default`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`integer type matches integers, an integer is an integer`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`number type matches numbers, an integer is a number`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`number type matches numbers, a float is a number`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`string type matches strings, a string is a string`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`string type matches strings, a string is still a string, even if it looks like a number`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`object type matches objects, an object is an object`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`array type matches arrays, an array is an array`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`boolean type matches booleans, a boolean is a boolean`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`null type matches only the null object, null is null`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple types can be specified in an array, an integer is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`multiple types can be specified in an array, a string is valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
+|`uniqueItems validation, unique array of integers is valid`|Expected result: `true` but validator returned: `false`
+|`uniqueItems validation, unique array of objects is valid`|Expected result: `true` but validator returned: `false`
+|`uniqueItems validation, unique array of nested objects is valid`|Expected result: `true` but validator returned: `false`
+|`uniqueItems validation, unique array of arrays is valid`|Expected result: `true` but validator returned: `false`
+|`uniqueItems validation, 1 and true are unique`|Expected result: `true` but validator returned: `false`
+|`uniqueItems validation, 0 and false are unique`|Expected result: `true` but validator returned: `false`
+|`uniqueItems validation, unique heterogeneous types are valid`|Expected result: `true` but validator returned: `false`
 
 **All other tests passed**.
 

--- a/reports/jsonschema.md
+++ b/reports/jsonschema.md
@@ -1,8 +1,5 @@
 # [`jsonschema`](https://github.com/tdegrunt/jsonschema#readme) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`jsonschema`](https://github.com/tdegrunt/jsonschema#readme) failed tests
 
@@ -14,6 +11,7 @@ that is the case for these tests.
 |`maxLength validation, two supplementary Unicode code points is long enough`|Expected result: `true` but validator returned: `false`
 |`minLength validation, one supplementary Unicode code point is not long enough`|Expected result: `false` but validator returned: `true`
 |`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, valid tree`|Expected result: `true` but validator returned: `"no such schema <http://localhost:1234/node>"`
 |`Recursive references between schemas, invalid tree`|Expected result: `false` but validator returned: `"no such schema <http://localhost:1234/node>"`
 |`base URI change - change folder, number is valid`|Expected result: `true` but validator returned: `"no such schema <http://localhost:1234/folderInteger.json>"`

--- a/reports/request-validator.md
+++ b/reports/request-validator.md
@@ -1,8 +1,5 @@
 # [`request-validator`](https://github.com/bugventure/request-validator) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`request-validator`](https://github.com/bugventure/request-validator) failed tests
 
@@ -32,6 +29,7 @@ that is the case for these tests.
 |`validation of host names, a host name starting with an illegal character`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name containing illegal characters`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name with a component too long`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`escaped pointer ref, slash valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
 |`escaped pointer ref, tilda valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**
 |`escaped pointer ref, percent valid`|Expected result: `true` but validator returned: `false`. **This excludes this validator from performance tests**

--- a/reports/revalidator.md
+++ b/reports/revalidator.md
@@ -1,8 +1,5 @@
 # [`revalidator`](https://github.com/flatiron/revalidator) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`revalidator`](https://github.com/flatiron/revalidator) failed tests
 
@@ -43,18 +40,18 @@ that is the case for these tests.
 |`enums in properties, missing required property is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`enums in properties, missing all properties is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`a schema given for items, wrong type of items`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
-|`an array of schemas for items, wrong types`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
+|`an array of schemas for items, wrong types`|Expected result: `false` but validator returned: `true`
 |`maxItems validation, too long is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`maxLength validation, too long is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`maxProperties validation, too long is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`maximum validation, above the maximum is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
-|`exclusiveMaximum validation, boundary point is invalid`|Expected result: `false` but validator returned: `true`
+|`exclusiveMaximum validation, boundary point is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`minItems validation, too short is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`minLength validation, too short is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`minLength validation, one supplementary Unicode code point is not long enough`|Expected result: `false` but validator returned: `true`
 |`minProperties validation, too short is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`minimum validation, below the minimum is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
-|`exclusiveMinimum validation, boundary point is invalid`|Expected result: `false` but validator returned: `true`
+|`exclusiveMinimum validation, boundary point is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`by int, int by int fail`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`by number, 35 is not multiple of 1.5`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`by small number, 0.00751 is not multiple of 0.0001`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
@@ -87,6 +84,7 @@ that is the case for these tests.
 |`validation of host names, a host name starting with an illegal character`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name containing illegal characters`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name with a component too long`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`pattern validation, a non-matching pattern is invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`properties, patternProperties, additionalProperties interaction, additionalProperty validates others`|Expected result: `true` but validator returned: `"Cannot read property 'format' of undefined"`. **This excludes this validator from performance tests**
 |`properties, patternProperties, additionalProperties interaction, additionalProperty invalidates others`|Expected result: `false` but validator returned: `"Cannot read property 'format' of undefined"`. **This excludes this validator from performance tests**
@@ -98,7 +96,7 @@ that is the case for these tests.
 |`escaped pointer ref, percent invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`nested refs, nested ref invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
 |`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
-|`ref overrides any sibling keywords, ref invalid`|Expected result: `false` but validator returned: `true`. **This excludes this validator from performance tests**
+|`ref overrides any sibling keywords, ref invalid`|Expected result: `false` but validator returned: `true`
 |`remote ref, containing refs itself, remote ref invalid`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, invalid tree`|Expected result: `false` but validator returned: `true`
 |`remote ref, remote ref invalid`|Expected result: `false` but validator returned: `true`

--- a/reports/schemasaurus.md
+++ b/reports/schemasaurus.md
@@ -1,8 +1,5 @@
 # [`schemasaurus`](https://github.com/AlexeyGrishin/schemasaurus) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`schemasaurus`](https://github.com/AlexeyGrishin/schemasaurus) failed tests
 
@@ -18,6 +15,7 @@ that is the case for these tests.
 |`maxLength validation, two supplementary Unicode code points is long enough`|Expected result: `true` but validator returned: `false`
 |`minLength validation, one supplementary Unicode code point is not long enough`|Expected result: `false` but validator returned: `true`
 |`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|The schema failed to load(`Unknown format 'regex'. Did you forget to register it?`)
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`remote ref, containing refs itself, remote ref valid`|The schema failed to load(`Remote refs are not supported for now :(`)
 |`remote ref, containing refs itself, remote ref invalid`|The schema failed to load(`Remote refs are not supported for now :(`)
 |`Recursive references between schemas, valid tree`|The schema failed to load(`Cannot read property 'split' of undefined`)

--- a/reports/skeemas.md
+++ b/reports/skeemas.md
@@ -1,8 +1,5 @@
 # [`skeemas`](https://github.com/Prestaul/skeemas#readme) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`skeemas`](https://github.com/Prestaul/skeemas#readme) failed tests
 
@@ -15,6 +12,7 @@ that is the case for these tests.
 |`an array of schemas for items, incomplete array of items`|Expected result: `true` but validator returned: `"validators.types[type] is not a function"`
 |`an array of schemas for items, empty array`|Expected result: `true` but validator returned: `"validators.types[type] is not a function"`
 |`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, valid tree`|Expected result: `true` but validator returned: `"Unable to locate JSON Ref (http://localhost:1234/treenode)"`
 |`Recursive references between schemas, invalid tree`|Expected result: `false` but validator returned: `"Unable to locate JSON Ref (http://localhost:1234/treenode)"`
 |`base URI change - change folder, number is valid`|Expected result: `true` but validator returned: `"Unable to locate JSON Ref (http://localhost:1234/scope_change_defs1.jsonfolder/folderInteger.json)"`

--- a/reports/themis.md
+++ b/reports/themis.md
@@ -1,0 +1,38 @@
+# [`themis`](https://github.com/playlyfe/themis) - test summary
+
+
+# [`themis`](https://github.com/playlyfe/themis) failed tests
+
+Some validators have deliberately chosen not to support parts of the spec. Go to the [`themis`](https://github.com/playlyfe/themis) homepage to learn if
+that is the case for these tests.
+
+|test failed|reason
+|-----------|------
+|`valid definition, valid definition schema`|Expected result: `true` but validator returned: `"validators.http://json-schema.org/draft-04/schema# is not a function"`
+|`invalid definition, invalid definition schema`|Expected result: `false` but validator returned: `"validators.http://json-schema.org/draft-04/schema# is not a function"`
+|`ECMA 262 regex non-compliance, ECMA 262 has no support for \Z anchor from .NET`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
+|`ref overrides any sibling keywords, ref valid, maxItems ignored`|Expected result: `true` but validator returned: `false`
+|`remote ref, containing refs itself, remote ref valid`|Expected result: `true` but validator returned: `"validators.http://json-schema.org/draft-04/schema# is not a function"`
+|`remote ref, containing refs itself, remote ref invalid`|Expected result: `false` but validator returned: `"validators.http://json-schema.org/draft-04/schema# is not a function"`
+|`Recursive references between schemas, valid tree`|The schema failed to load(`Cannot read property '0' of undefined`)
+|`Recursive references between schemas, invalid tree`|The schema failed to load(`Cannot read property '0' of undefined`)
+|`remote ref, remote ref valid`|Expected result: `true` but validator returned: `"validators.http://localhost:1234/integer.json is not a function"`
+|`remote ref, remote ref invalid`|Expected result: `false` but validator returned: `"validators.http://localhost:1234/integer.json is not a function"`
+|`fragment within remote ref, remote fragment valid`|Expected result: `true` but validator returned: `"validators.http://localhost:1234/subSchemas.json#/integer is not a function"`
+|`fragment within remote ref, remote fragment invalid`|Expected result: `false` but validator returned: `"validators.http://localhost:1234/subSchemas.json#/integer is not a function"`
+|`ref within remote ref, ref within ref valid`|Expected result: `true` but validator returned: `"validators.http://localhost:1234/subSchemas.json#/refToInteger is not a function"`
+|`ref within remote ref, ref within ref invalid`|Expected result: `false` but validator returned: `"validators.http://localhost:1234/subSchemas.json#/refToInteger is not a function"`
+|`base URI change, base URI change ref valid`|The schema failed to load(`invalid ref: folderInteger.json in folder/`)
+|`base URI change, base URI change ref invalid`|The schema failed to load(`invalid ref: folderInteger.json in folder/`)
+|`base URI change - change folder, number is valid`|The schema failed to load(`invalid ref: folderInteger.json in folder/`)
+|`base URI change - change folder, string is invalid`|The schema failed to load(`invalid ref: folderInteger.json in folder/`)
+|`base URI change - change folder in subschema, number is valid`|The schema failed to load(`invalid ref: folderInteger.json in folder/`)
+|`base URI change - change folder in subschema, string is invalid`|The schema failed to load(`invalid ref: folderInteger.json in folder/`)
+|`root ref in remote ref, string is valid`|The schema failed to load(`Cannot read property 'definitions' of undefined`)
+|`root ref in remote ref, null is valid`|The schema failed to load(`Cannot read property 'definitions' of undefined`)
+|`root ref in remote ref, object is invalid`|The schema failed to load(`Cannot read property 'definitions' of undefined`)
+
+**All other tests passed**.
+
+[back to benchmarks](https://github.com/ebdrup/json-schema-benchmark)

--- a/reports/tv4.md
+++ b/reports/tv4.md
@@ -1,8 +1,5 @@
 # [`tv4`](https://github.com/geraintluff/tv4) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`tv4`](https://github.com/geraintluff/tv4) failed tests
 
@@ -31,6 +28,7 @@ that is the case for these tests.
 |`validation of host names, a host name starting with an illegal character`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name containing illegal characters`|Expected result: `false` but validator returned: `true`
 |`validation of host names, a host name with a component too long`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`remote ref, containing refs itself, remote ref invalid`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, invalid tree`|Expected result: `false` but validator returned: `true`
 |`remote ref, remote ref invalid`|Expected result: `false` but validator returned: `true`

--- a/reports/z-schema.md
+++ b/reports/z-schema.md
@@ -1,8 +1,5 @@
 # [`z-schema`](https://github.com/zaggino/z-schema) - test summary
 
-# All validators fail this test
-
-`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`
 
 # [`z-schema`](https://github.com/zaggino/z-schema) failed tests
 
@@ -15,6 +12,7 @@ that is the case for these tests.
 |`validation of URIs, an invalid protocol-relative URI Reference`|Expected result: `false` but validator returned: `true`
 |`validation of URIs, an invalid URI`|Expected result: `false` but validator returned: `true`
 |`validation of URIs, an invalid URI though valid URI reference`|Expected result: `false` but validator returned: `true`
+|`some languages do not distinguish between different types of numeric value, a float is not an integer even without fractional part`|Expected result: `false` but validator returned: `true`
 |`Recursive references between schemas, valid tree`|Expected result: `true` but validator returned: `false`
 |`base URI change - change folder, number is valid`|Expected result: `true` but validator returned: `false`
 |`base URI change - change folder in subschema, number is valid`|Expected result: `true` but validator returned: `false`

--- a/testRunner.js
+++ b/testRunner.js
@@ -45,15 +45,9 @@ module.exports = function (validators) {
 			});
 			var excludeTests = [
 				//lots of validators fail these
-				'invalid definition, invalid definition schema',
 				'maxLength validation, two supplementary Unicode code points is long enough',
 				'minLength validation, one supplementary Unicode code point is not long enough',
-				'an array of schemas for items, JavaScript pseudo-array is valid',
-				'ref overrides any sibling keywords, ref valid, maxItems ignored',
-				'Recursive references between schemas, invalid tree',
 				'a schema given for items, JavaScript pseudo-array is valid',
-				'an array of schemas for items, incomplete array of items',
-				'an array of schemas for items, empty array',
 				'required validation, ignores non-objects',
 				'heterogeneous enum validation, something else is invalid'
 			];
@@ -63,18 +57,16 @@ module.exports = function (validators) {
 				'fragment within remote ref',
 				'ref within remote ref',
 				'change resolution scope',
+				'ref overrides any sibling keywords',
+				'an array of schemas for items',
 				'uniqueItems validation',
 				'valid definition',
 				'invalid definition',
-				'exclusiveMaximum validation',
-				'exclusiveMinimum validation',
 				'Recursive references between schemas',
 				'base URI change',
 				'base URI change - change folder',
 				'base URI change - change folder in subschema',
 				'root ref in remote ref',
-				'float comparison with high precision',
-				'float comparison with high precision on negative numbers',
 				'ECMA 262 regex non-compliance'
 			];
 			var testSuites = readTests(path.join(__dirname + '/JSON-Schema-Test-Suite/tests/draft4/'));


### PR DESCRIPTION
The reason Ajv was failing the tests is that version 5.x requires explicitly adding draft-04 meta schema and making it default, otherwise it supports draft-06.

I am not sure why jsen and themis were throwing, they didn't throw for me.