### PR TITLE
fix(djv): Update djv environment to use draft-04 version

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ testRunner([
 	{
 		name: 'djv',
 		setup: function (schema) {
+			djv.useVersion('draft-04');
 			return djv.addSchema('test', schema).fn;
 		},
 		test: function (instance, json, schema) {


### PR DESCRIPTION
For the next major update of `djv` package - 2.0.0 by default uses `draft-06`. This PR is intended to fix benchmark tests for `djv` to use `draft-04` version.

https://github.com/korzio/djv/issues/48
https://www.npmjs.com/package/djv