### PR TITLE
Add @cfworker/json-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "main": "benchmark.js",
   "license": "MIT",
   "dependencies": {
+    "@cfworker/json-schema": "*",
     "JSV": "*",
     "ajv": "*",
     "async": "^2.6.1",

--- a/testRunner.js
+++ b/testRunner.js
@@ -390,7 +390,14 @@ function saveResults(results, validators, allTestNames, testsThatAllValidatorsFa
           })
         )
       });
-      var testSummaryPath = path.join(__dirname, "/reports/", validator.name.replace('/', '--') + ".md");
+      var testSummaryPath = path.join(__dirname, "/reports/", validator.name + ".md");
+      if (validator.name.startsWith('@')) {
+        const scope = validator.name.substr(0, validator.name.indexOf('/'));
+        const scopeDir = path.join(__dirname, "/reports/", scope);
+        if (!fs.existsSync(scopeDir)) {
+          fs.mkdirSync(scopeDir);
+        }
+      }
       fs.writeFileSync(testSummaryPath, html);
     });
     validatorsSideEffects.forEach(function(sideEffects) {

--- a/testRunner.js
+++ b/testRunner.js
@@ -390,7 +390,7 @@ function saveResults(results, validators, allTestNames, testsThatAllValidatorsFa
           })
         )
       });
-      var testSummaryPath = path.join(__dirname, "/reports/", validator.name + ".md");
+      var testSummaryPath = path.join(__dirname, "/reports/", validator.name.replace('/', '--') + ".md");
       fs.writeFileSync(testSummaryPath, html);
     });
     validatorsSideEffects.forEach(function(sideEffects) {


### PR DESCRIPTION
[`@cfworker/json-schema`](https://github.com/cfworker/cfworker/blob/master/packages/json-schema/README.md) is a validator that does not use code generation (`eval` or `new Function`). It's compatible with drafts 4, 7, and 2019-09.

`eval` and friends are not available in Cloudflare Workers so ajv style validators can't be used with dynamic schemas. The other non-code-generating validators are pretty out of date with the latest spec so I created yet another validator :roll_eyes: 

This PR:
1. Adds support for scoped packages in testRunner.js
2. Makes minimal changes to index.js to support modern `type: module` packages.
3. Adds `@cfworker/json-schema` to the list of validators

I'm sure changes will be required, I tried to use a light touch when making the module support changes.

Depending on your version of node you'll need to add some command line arguments to enable module support. I'm using `v13.13.0`.
```
node --experimental-modules --es-module-specifier-resolution=node index.js
```

Thanks for putting this benchmark together by the way, it's been super helpful for myself and the community.