### PR TITLE
Add @exodus/schemasafe

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const ajv = require("ajv")({ schemaId: "auto" });
 const djv = require("djv")();
 const jsvg = require("json-schema-validator-generator").default;
 const jlib = require("json-schema-library");
+const schemasafe = require("@exodus/schemasafe");
 let cfworker;
 
 const refs = {
@@ -269,6 +270,19 @@ const validators = [
     test: function(instance, json, schema) {
       return instance.isValid(json);
     },
+  },
+  {
+    name: "@exodus/schemasafe",
+    setup: function(schema) {
+      return schemasafe.validator(schema, {
+        allowUnusedKeywords: true,
+        schemas: refs,
+        $schemaDefault: "https://json-schema.org/draft-06/schema",
+      });
+    },
+    test: function(instance, json, schema) {
+      return instance(json);
+    }
   },
   {
     name: "@cfworker/json-schema",

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,11 @@
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-1.1.4.tgz",
       "integrity": "sha512-l5H5QfXLmpQ1pT1p6KxJXw37YhRF9M51UMFH8RWZhMRuH6l1QzUiZG80lkzuxCBkdCasIEHiUPld2rplApVEHg=="
     },
+    "@exodus/schemasafe": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-jpTz8uh12smCZiwvy7Va6ODoEnnHzOlW3eluG2gnsI85URJS6YBxrsr9AUfWNTG6oopdCIWnPJBklPVRwUk6pQ=="
+    },
     "@korzio/djv-draft-04": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@korzio/djv-draft-04/-/djv-draft-04-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "dependencies": {
     "@cfworker/json-schema": "*",
+    "@exodus/schemasafe": "^1.0.0-alpha.4",
     "JSV": "*",
     "ajv": "*",
     "async": "^3.2.0",


### PR DESCRIPTION
Things to note:
1. `allowUnusedKeywords` is required because that's what specification is expecting, and there are tests for that. By default, `@exodus/schemasafe` instead refuses to compile a schema with unused keywords to prevent failing in open state on e.g. schema author mistakes -- similar to how `ajv` behaves with `strictKeywords` option, but with deeper checks.
   
   That option does not affect the produced code or performance, it just affects whether the schema would be refused to compile or not.
2. Structured reporting is [disabled](https://github.com/ExodusMovement/schemasafe/blob/master/doc/Error-handling.md) by default, instead just a boolean validation status is reported — because if the user wants errors, they would enable them, and if they don't need errors and need just the result — they might forget to disable it for performance.
   
   I'm not sure how fair is that to other validators in this benchmark. If it's not -- just add `includeErrors: true,` to the options ;-)
3. Default `$schema` value is needed because `$schema` is not specified in all tests, and behavior differs between various spec versions. Specifically, `$ref` behavior changed in `draft2019-09`, and there is a test for that. Out of those two, `draft2019-09` behavior is more secure and makes more sense, hence that's the default in schemasafe unless `$schema` is specified in the schema or `$schemaDefault` is specified in options.