### PR TITLE
Update @exodus/schemasafe config

### DIFF
--- a/validators.js
+++ b/validators.js
@@ -300,7 +300,7 @@ module.exports = async function valivators(draftUri, draftVersion) {
           allowUnusedKeywords: true,
           includeErrors: true,
           schemas: refs,
-          $schemaDefault: "https://json-schema.org/draft-06/schema",
+          $schemaDefault: draftUri,
         });
       },
       test: function(instance, json, schema) {

--- a/validators.js
+++ b/validators.js
@@ -297,7 +297,9 @@ module.exports = async function valivators(draftUri, draftVersion) {
       name: "@exodus/schemasafe",
       setup: function(schema) {
         return schemasafe.validator(schema, {
+          // some tests are ill-formed on a purpose, we disable bail-out on those to check the actual behavior
           allowUnusedKeywords: true,
+          allowUnreachable: true,
           includeErrors: true,
           schemas: refs,
           $schemaDefault: draftUri,


### PR DESCRIPTION
Two changes here:
1. As this repo now tests on multiple drafts, actually pass the correct draft uri (like to other validators) instead of hardcoding `draft-06`.
2. Disable compile-time bail-out on unreachable checks.

To explain (2), schemasafe in default configuration does not allow schemas that can be proven to have unreachable checks, e.g. 
* `{ "type": "array", "maxLength": 2 }` — `maxLength` doesn't do anything on arrays.
*  `{  "anyOf": [  { "type": "number" },  {} ] }` — first check doesn't do anything because second always passes.
   _The static check for this one disabled by `allowUnreachable`._

`allow***` options disable some of those checks, allowing some ill-formed schemas to compile.
Those options do not change the runtime behavior of any schemas.

The testsuite includes those ill-formed schemas on a purpose, to test that some parts have no effect on the behavior (assuming they are allowed to compile), and in order to check the runtime behavior here (and compare to the other impls) we have to disable the static checks.