### PR TITLE
chore: update schemasafe to 1.0.0-rc.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "*",
-        "@exodus/schemasafe": "^1.0.0-rc.3",
+        "@exodus/schemasafe": "^1.0.0-rc.6",
         "ajv": "*",
         "async": "^3.2.0",
         "benchmark": "^2.1.4",
@@ -151,9 +151,9 @@
       "integrity": "sha512-W4WlJFm2xZqzui/ef0fc/W8BJ2425IKdUuix/LqlIP16htwAcbRGHzGHh9Jm0LfJOKS4ZqTjBXIyzBGqufe+ig=="
     },
     "node_modules/@exodus/schemasafe": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.3.tgz",
-      "integrity": "sha512-GoXw0U2Qaa33m3eUcxuHnHpNvHjNlLo0gtV091XBpaRINaB4X6FGCG5XKxSFNFiPpugUDqNruHzaqpTdDm4AOg=="
+      "version": "1.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
+      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
     },
     "node_modules/@korzio/djv-draft-04": {
       "version": "2.0.1",
@@ -768,7 +768,6 @@
         "babel-polyfill": "^6.26.0",
         "babel-register": "^6.26.0",
         "babel-runtime": "^6.26.0",
-        "chokidar": "^1.6.1",
         "commander": "^2.11.0",
         "convert-source-map": "^1.5.0",
         "fs-readdir-recursive": "^1.0.0",
@@ -1891,7 +1890,6 @@
       "dependencies": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -2404,9 +2402,6 @@
       "version": "2.1.3-alpha.0",
       "resolved": "https://registry.npmjs.org/djv/-/djv-2.1.3-alpha.0.tgz",
       "integrity": "sha512-vrKAFr/wbhMjfqo+eoXZRIx/6YbN1DSZlxUsE3tHDPYB0zWRtOBhqmKbcgCjfP3+KevqidBGn2jNRnqRhjIzYg==",
-      "dependencies": {
-        "@korzio/djv-draft-04": "^2.0.1"
-      },
       "optionalDependencies": {
         "@korzio/djv-draft-04": "^2.0.1"
       }
@@ -2625,8 +2620,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -4623,7 +4617,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -6090,9 +6083,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -7836,7 +7826,6 @@
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
       },
@@ -10856,7 +10845,6 @@
       "license": "ISC",
       "dependencies": {
         "debuglog": "^1.0.1",
-        "graceful-fs": "^4.1.2",
         "read-package-json": "^2.0.0",
         "readdir-scoped-modules": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
@@ -10875,7 +10863,6 @@
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
         "json-parse-better-errors": "^1.0.1",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
@@ -11305,13 +11292,9 @@
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
         "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "safer-buffer": "^2.0.2"
       },
       "bin": {
         "sshpk-conv": "bin/sshpk-conv",
@@ -15255,7 +15238,6 @@
       "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.0.tgz",
       "integrity": "sha512-58TxNEurHQEEgbrNbQnoUHXgh6tiplSvKb7D3o4K6KzICQk9vFyl8B0zycC/p3gW92qBZCmq5NJIhJODKrV7JQ==",
       "dependencies": {
-        "commander": "^2.7.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "validator": "^12.0.0"
@@ -15381,9 +15363,9 @@
       "integrity": "sha512-W4WlJFm2xZqzui/ef0fc/W8BJ2425IKdUuix/LqlIP16htwAcbRGHzGHh9Jm0LfJOKS4ZqTjBXIyzBGqufe+ig=="
     },
     "@exodus/schemasafe": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.3.tgz",
-      "integrity": "sha512-GoXw0U2Qaa33m3eUcxuHnHpNvHjNlLo0gtV091XBpaRINaB4X6FGCG5XKxSFNFiPpugUDqNruHzaqpTdDm4AOg=="
+      "version": "1.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.6.tgz",
+      "integrity": "sha512-dDnQizD94EdBwEj/fh3zPRa/HWCS9O5au2PuHhZBbuM3xWHxuaKzPBOEWze7Nn0xW68MIpZ7Xdyn1CoCpjKCuQ=="
     },
     "@korzio/djv-draft-04": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "dependencies": {
     "@cfworker/json-schema": "*",
-    "@exodus/schemasafe": "^1.0.0-rc.3",
+    "@exodus/schemasafe": "^1.0.0-rc.6",
     "ajv": "*",
     "async": "^3.2.0",
     "benchmark": "^2.1.4",


### PR DESCRIPTION
This introduces `draft/2020-12` support, along with performance improvements and some format fixes.

Also `package-lock.json` changes generated by npm 7.20.3.