### PR TITLE
Add zod to the benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "json-stringify-safe": "^5.0.1",
     "jsonschema": "*",
     "JSV": "*",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "mustache": "^4.0.1",
     "npm": "^6.14.9",
     "request-validator": "*",
@@ -33,6 +33,7 @@
     "skeemas": "*",
     "themis": "*",
     "tv4": "*",
+    "zod": "*",
     "z-schema": "*"
   },
   "description": "Benchmarks for Node.js JSON-schema validators",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "json-stringify-safe": "^5.0.1",
     "jsonschema": "*",
     "JSV": "*",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.20",
     "mustache": "^4.0.1",
     "npm": "^6.14.9",
     "request-validator": "*",

--- a/validators.js
+++ b/validators.js
@@ -22,6 +22,7 @@ const djv = require("djv")();
 const jsvg = require("json-schema-validator-generator").default;
 const jlib = require("json-schema-library");
 const schemasafe = require("@exodus/schemasafe");
+const zod = require("zod");
 let cfworker;
 
 module.exports = async function valivators(draftUri, draftVersion) {
@@ -305,6 +306,15 @@ module.exports = async function valivators(draftUri, draftVersion) {
       },
       test: function(instance, json, schema) {
         return instance(json);
+      },
+    },
+    {
+      name: "zod",
+      setup: function(schema) {
+        return zod.inferType(schema);
+      },
+      test: function(instance, json, schema) {
+        return instance.parse(json);
       },
     },
     {


### PR DESCRIPTION
Addresses issue #66

[zod](https://github.com/colinhacks/zod) is quickly growing in popularity as a json-schema validator. It is now added to the benchmark so it can be compared with the other validators.

Result of running ```node index.js``` in the terminal (zod is highlighted). I commented out the part of the code that limits the logging to the top 6 results, so that all validators are shown for comparison. Also note that the current sorting (which I did not modify) is from least to greatest number of failing tests. 

Draft 7 test suite:
<img width="668" alt="draft7" src="https://github.com/ebdrup/json-schema-benchmark/assets/28958079/0b897652-700d-4db7-8cb0-f97a8c92f650">

Draft 6 test suite:
<img width="668" alt="draft6" src="https://github.com/ebdrup/json-schema-benchmark/assets/28958079/e0579c24-4426-46b6-bd72-345ca91d2ece">

Draft 4 test suite:
<img width="668" alt="draft4" src="https://github.com/ebdrup/json-schema-benchmark/assets/28958079/dd2629bb-af5b-4474-80aa-01dd9cc9aaf5">
